### PR TITLE
Add plants list page

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -39,10 +39,9 @@ export default function AddPlantForm() {
         <label>Species</label>
         <SpeciesAutosuggest
           value={species}
-          onChange={setSpecies}
-          onSelect={(scientificName: string, common: string) => {
+          onSelect={(scientificName: string, common?: string) => {
             setSpecies(scientificName);
-            setCommonName(common); // 👈 auto-fill
+            setCommonName(common || ""); // 👈 auto-fill
           }}
         />
       </div>

--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,9 +1,8 @@
-export async function POST(req: Request) {
-  const body = await req.json();
+export async function POST() {
   return Response.json({
     waterEvery: "7 days",
     fertEvery: "Monthly",
     fertFormula: "10-10-10",
-    rationale: "Based on your plant’s pot size, light, and humidity."
+    rationale: "Based on your plant’s pot size, light, and humidity.",
   });
 }

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -32,9 +32,10 @@ export async function POST(req: Request) {
     if (error) throw error;
 
     return NextResponse.json({ data });
-  } catch (err: any) {
-    console.error("POST /plants error:", err.message);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("POST /plants error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
@@ -45,7 +46,8 @@ export async function GET() {
     if (error) throw error;
 
     return NextResponse.json({ data });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/species/route.ts
+++ b/src/app/api/species/route.ts
@@ -8,12 +8,21 @@ async function fetchPerenual(q: string) {
   if (!res.ok) throw new Error(`Perenual API error: ${res.status}`);
   const body = await res.json();
 
-  return body?.data?.map((p: any) => ({
-    id: `perenual-${p.id}`,
-    common_name: p.common_name,
-    scientific_name: p.scientific_name,
-    image_url: p.default_image?.thumbnail,
-  })) ?? [];
+  type PerenualPlant = {
+    id: number;
+    common_name: string;
+    scientific_name: string;
+    default_image?: { thumbnail?: string };
+  };
+
+  return (
+    body?.data?.map((p: PerenualPlant) => ({
+      id: `perenual-${p.id}`,
+      common_name: p.common_name,
+      scientific_name: p.scientific_name,
+      image_url: p.default_image?.thumbnail,
+    })) ?? []
+  );
 }
 
 async function fetchTrefle(q: string) {
@@ -23,12 +32,21 @@ async function fetchTrefle(q: string) {
   if (!res.ok) throw new Error(`Trefle API error: ${res.status}`);
   const body = await res.json();
 
-  return body?.data?.map((p: any) => ({
-    id: `trefle-${p.id}`,
-    common_name: p.common_name,
-    scientific_name: p.scientific_name,
-    image_url: p.image_url,
-  })) ?? [];
+  type TreflePlant = {
+    id: number;
+    common_name: string;
+    scientific_name: string;
+    image_url?: string;
+  };
+
+  return (
+    body?.data?.map((p: TreflePlant) => ({
+      id: `trefle-${p.id}`,
+      common_name: p.common_name,
+      scientific_name: p.scientific_name,
+      image_url: p.image_url,
+    })) ?? []
+  );
 }
 
 export async function GET(req: Request) {
@@ -46,8 +64,9 @@ export async function GET(req: Request) {
     }
 
     return NextResponse.json({ data: results });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Species API error:", err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,0 +1,53 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const revalidate = 0;
+
+type Plant = {
+  id: string;
+  name: string;
+  species: string | null;
+  common_name: string | null;
+};
+
+export default async function PlantsPage() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const { data, error } = await supabase
+    .from("plants")
+    .select("id, name, species, common_name")
+    .order("name");
+
+  const plants = data as Plant[] | null;
+
+  if (error) {
+    console.error("Error fetching plants:", error.message);
+    return <div>Failed to load plants.</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Plants</h1>
+      {plants && plants.length > 0 ? (
+        <ul className="space-y-4">
+          {plants.map((plant) => (
+            <li key={plant.id} className="rounded border p-4">
+              <div className="font-semibold">{plant.name}</div>
+              {plant.common_name && (
+                <div className="text-sm text-gray-600">{plant.common_name}</div>
+              )}
+              {plant.species && (
+                <div className="text-sm italic text-gray-600">{plant.species}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No plants saved yet.</p>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/plants` page that lists stored plants with common and scientific names
- tidy API handlers and add page for type safety

## Testing
- `pnpm lint`
- `NEXT_PUBLIC_SUPABASE_URL='http://example.com' SUPABASE_SERVICE_ROLE_KEY='service' pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a662946eb4832483092ac60e454618