### PR TITLE
Add plant detail page with timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,28 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Flora
 
-## Getting Started
+Flora is a personalized plant care companion built with Next.js and Supabase.
 
-First, run the development server:
+## Features
+
+- Add plants with species autosuggest.
+- View a list of all saved plants.
+- Open a plant to see its detail page with a timeline of care events.
+
+## Development
+
+Install dependencies and start the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Set the following environment variables in `.env.local` to connect to Supabase:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Roadmap
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+See [ROADMAP.md](ROADMAP.md) for planned and in‑progress work.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [ ] Photo + Name hero section
 - [ ] Quick Stats: care plan values, last watered, next due
-- [ ] Timeline of logged events (watering, fertilizing, notes)
+- [x] Timeline of logged events (watering, fertilizing, notes)
 - [ ] Notes section (freeform journaling)
 - [ ] Photo gallery
 - [ ] Edit button for care plan
@@ -115,7 +115,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 ## 🧭 Next Steps
 
-- [ ] Wrap up Plant Detail timeline view
+- [x] Wrap up Plant Detail timeline view
 - [ ] Build Rooms + Plant List page
 - [ ] Add `/app/today` for task view
 - [ ] Evaluate Supabase Auth vs hardcoded single-user fallback

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,0 +1,77 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const revalidate = 0;
+
+type Plant = {
+  id: string;
+  name: string;
+  species: string | null;
+  common_name: string | null;
+};
+
+type PlantEvent = {
+  id: string;
+  type: string;
+  note: string | null;
+  created_at: string;
+};
+
+export default async function PlantDetailPage({ params }: { params: { id: string } }) {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const { data: plant, error: plantError } = await supabase
+    .from("plants")
+    .select("id, name, species, common_name")
+    .eq("id", params.id)
+    .single<Plant>();
+
+  if (plantError || !plant) {
+    console.error("Error fetching plant:", plantError?.message);
+    return <div>Failed to load plant.</div>;
+  }
+
+  const { data: events } = await supabase
+    .from("events")
+    .select("id, type, note, created_at")
+    .eq("plant_id", params.id)
+    .order("created_at", { ascending: false });
+
+  const timeline = events as PlantEvent[] | null;
+
+  return (
+    <div className="space-y-6 p-4">
+      <div>
+        <h1 className="text-2xl font-bold">{plant.name}</h1>
+        {plant.common_name && (
+          <p className="text-gray-600">{plant.common_name}</p>
+        )}
+        {plant.species && (
+          <p className="text-sm italic text-gray-600">{plant.species}</p>
+        )}
+      </div>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Timeline</h2>
+        {timeline && timeline.length > 0 ? (
+          <ul className="space-y-2">
+            {timeline.map((evt) => (
+              <li key={evt.id} className="rounded border p-2">
+                <div className="text-sm text-gray-500">
+                  {new Date(evt.created_at).toLocaleString()}
+                </div>
+                <div className="font-medium">{evt.type}</div>
+                {evt.note && <div className="text-sm">{evt.note}</div>}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No events logged yet.</p>
+        )}
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { createClient } from "@supabase/supabase-js";
 
 export const revalidate = 0;
@@ -33,14 +34,23 @@ export default async function PlantsPage() {
       {plants && plants.length > 0 ? (
         <ul className="space-y-4">
           {plants.map((plant) => (
-            <li key={plant.id} className="rounded border p-4">
-              <div className="font-semibold">{plant.name}</div>
-              {plant.common_name && (
-                <div className="text-sm text-gray-600">{plant.common_name}</div>
-              )}
-              {plant.species && (
-                <div className="text-sm italic text-gray-600">{plant.species}</div>
-              )}
+            <li key={plant.id}>
+              <Link
+                href={`/plants/${plant.id}`}
+                className="block rounded border p-4"
+              >
+                <div className="font-semibold">{plant.name}</div>
+                {plant.common_name && (
+                  <div className="text-sm text-gray-600">
+                    {plant.common_name}
+                  </div>
+                )}
+                {plant.species && (
+                  <div className="text-sm italic text-gray-600">
+                    {plant.species}
+                  </div>
+                )}
+              </Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- add dynamic plant detail page that shows basic info and a timeline of care events
- link plant list items to their detail pages
- document current features and env vars in README and update roadmap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a66743f21c8324878f02c5c500d641