### PR TITLE
feat: add rooms to plant list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 ## Features
 
 - Add plants with species autosuggest.
-- View a list of all saved plants.
+- Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
 
 ## Development

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 ## 🧭 Next Steps
 
 - [x] Wrap up Plant Detail timeline view
-- [ ] Build Rooms + Plant List page
+- [x] Build Rooms + Plant List page
 - [ ] Add `/app/today` for task view
 - [ ] Evaluate Supabase Auth vs hardcoded single-user fallback
 - [ ] Polish visual style, typography, and interactions

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -7,6 +7,7 @@ export default function AddPlantForm() {
   const [name, setName] = useState("");
   const [species, setSpecies] = useState("");
   const [commonName, setCommonName] = useState(""); // 👈
+  const [room, setRoom] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -14,13 +15,14 @@ export default function AddPlantForm() {
     const res = await fetch("/api/plants", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, species, commonName }),
+      body: JSON.stringify({ name, species, commonName, room }),
     });
 
     if (res.ok) {
       setName("");
       setSpecies("");
       setCommonName("");
+      setRoom("");
     }
   };
 
@@ -43,6 +45,15 @@ export default function AddPlantForm() {
             setSpecies(scientificName);
             setCommonName(common || ""); // 👈 auto-fill
           }}
+        />
+      </div>
+
+      <div>
+        <label>Room</label>
+        <input
+          type="text"
+          value={room}
+          onChange={(e) => setRoom(e.target.value)}
         />
       </div>
 

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   try {
     const body = await req.json();
 
-    const { name, species, common_name, care_plan } = body;
+    const { name, species, common_name, room, care_plan } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Plant name is required" }, { status: 400 });
@@ -24,6 +24,7 @@ export async function POST(req: Request) {
           name,
           species,
           common_name,
+          room,
           care_plan,
         },
       ])

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -6,6 +6,7 @@ export const revalidate = 0;
 type Plant = {
   id: string;
   name: string;
+  room: string | null;
   species: string | null;
   common_name: string | null;
 };
@@ -18,7 +19,8 @@ export default async function PlantsPage() {
 
   const { data, error } = await supabase
     .from("plants")
-    .select("id, name, species, common_name")
+    .select("id, name, room, species, common_name")
+    .order("room")
     .order("name");
 
   const plants = data as Plant[] | null;
@@ -32,28 +34,40 @@ export default async function PlantsPage() {
     <div className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Plants</h1>
       {plants && plants.length > 0 ? (
-        <ul className="space-y-4">
-          {plants.map((plant) => (
-            <li key={plant.id}>
-              <Link
-                href={`/plants/${plant.id}`}
-                className="block rounded border p-4"
-              >
-                <div className="font-semibold">{plant.name}</div>
-                {plant.common_name && (
-                  <div className="text-sm text-gray-600">
-                    {plant.common_name}
-                  </div>
-                )}
-                {plant.species && (
-                  <div className="text-sm italic text-gray-600">
-                    {plant.species}
-                  </div>
-                )}
-              </Link>
-            </li>
-          ))}
-        </ul>
+        Object.entries(
+          plants.reduce((acc: Record<string, Plant[]>, plant) => {
+            const room = plant.room || "Unassigned";
+            acc[room] = acc[room] || [];
+            acc[room].push(plant);
+            return acc;
+          }, {})
+        ).map(([room, plants]) => (
+          <section key={room} className="mb-8">
+            <h2 className="mb-2 text-xl font-semibold">{room}</h2>
+            <ul className="space-y-4">
+              {plants.map((plant) => (
+                <li key={plant.id}>
+                  <Link
+                    href={`/plants/${plant.id}`}
+                    className="block rounded border p-4"
+                  >
+                    <div className="font-semibold">{plant.name}</div>
+                    {plant.common_name && (
+                      <div className="text-sm text-gray-600">
+                        {plant.common_name}
+                      </div>
+                    )}
+                    {plant.species && (
+                      <div className="text-sm italic text-gray-600">
+                        {plant.species}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
       ) : (
         <p>No plants saved yet.</p>
       )}

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -8,9 +8,13 @@ create table if not exists public.plants (
   id uuid primary key default gen_random_uuid(),
   name text not null,
   species text not null,
+  room text,
   care_plan jsonb,
   created_at timestamptz default now()
 );
+
+-- Ensure room column exists for existing installations
+alter table if exists public.plants add column if not exists room text;
 
 -- Species table
 create table if not exists public.species (


### PR DESCRIPTION
## Summary
- allow assigning plants to rooms when adding new plant
- group plant list by room
- document room feature and update roadmap

## Testing
- `pnpm lint`
- `pnpm build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a66914afa08324bae51b3608c4fb03