### PR TITLE
Add today task view

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Add plants with species autosuggest.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
+- Check today's care tasks on `/today`.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,6 +117,6 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [x] Wrap up Plant Detail timeline view
 - [x] Build Rooms + Plant List page
-- [ ] Add `/app/today` for task view
+- [x] Add `/app/today` for task view
 - [ ] Evaluate Supabase Auth vs hardcoded single-user fallback
 - [ ] Polish visual style, typography, and interactions

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,0 +1,54 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const revalidate = 0;
+
+type Task = {
+  id: string;
+  type: string;
+  due_date: string;
+  plant: { id: string; name: string }[];
+};
+
+export default async function TodayPage() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const today = new Date().toISOString().slice(0, 10);
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("id, type, due_date, plant:plants(id, name)")
+    .eq("due_date", today)
+    .order("due_date");
+
+  if (error) {
+    console.error("Error fetching tasks:", error.message);
+    return <div>Failed to load tasks.</div>;
+  }
+
+  const tasks = (data ?? []) as Task[];
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Today&apos;s Tasks</h1>
+      {tasks && tasks.length > 0 ? (
+        <ul className="space-y-4">
+          {tasks.map((task) => {
+            const plant = task.plant?.[0];
+            return (
+              <li key={task.id} className="rounded border p-4">
+                <div className="font-semibold">{task.type}</div>
+                {plant && (
+                  <div className="text-sm text-gray-600">{plant.name}</div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p>No tasks due today.</p>
+      )}
+    </div>
+  );
+}

--- a/supabase/tasks.sql
+++ b/supabase/tasks.sql
@@ -1,0 +1,25 @@
+-- Run this in Supabase SQL editor to set up tasks table
+
+-- Ensure pgcrypto extension
+create extension if not exists pgcrypto;
+
+-- Tasks table
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid references public.plants(id) on delete cascade,
+  type text not null,
+  due_date date not null,
+  completed_at timestamptz
+);
+
+-- Row Level Security
+alter table public.tasks enable row level security;
+
+-- Policies: open read/write for development
+drop policy if exists "public read tasks" on public.tasks;
+create policy "public read tasks" on public.tasks
+  for select using (true);
+
+drop policy if exists "public write tasks" on public.tasks;
+create policy "public write tasks" on public.tasks
+  for insert with check (true);


### PR DESCRIPTION
## Summary
- add `/today` route to list today's care tasks
- define `tasks` table SQL schema
- document new task dashboard

## Testing
- `pnpm lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a66a3b34388324a265f825960a9f10