### PR TITLE
feat: add plant notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Add plants with species autosuggest.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
+- Jot down freeform notes on each plant's detail page.
 - Check today's care tasks on `/today`.
 
 ## Development

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 - [ ] Photo + Name hero section
 - [ ] Quick Stats: care plan values, last watered, next due
 - [x] Timeline of logged events (watering, fertilizing, notes)
-- [ ] Notes section (freeform journaling)
+- [x] Notes section (freeform journaling)
 - [ ] Photo gallery
 - [ ] Edit button for care plan
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { plant_id, type, note } = body;
+
+    if (!plant_id || !type) {
+      return NextResponse.json({ error: "plant_id and type are required" }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from("events")
+      .insert([{ plant_id, type, note }])
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json({ data });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("POST /events error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import AddNoteForm from "@/components/AddNoteForm";
 
 export const revalidate = 0;
 
@@ -40,6 +41,8 @@ export default async function PlantDetailPage({ params }: { params: { id: string
     .order("created_at", { ascending: false });
 
   const timeline = events as PlantEvent[] | null;
+  const notes = timeline?.filter((e) => e.type === "note") || [];
+  const otherEvents = timeline?.filter((e) => e.type !== "note") || [];
 
   return (
     <div className="space-y-6 p-4">
@@ -53,11 +56,30 @@ export default async function PlantDetailPage({ params }: { params: { id: string
         )}
       </div>
 
+      <section className="space-y-4">
+        <h2 className="mb-2 font-semibold">Notes</h2>
+        <AddNoteForm plantId={plant.id} />
+        {notes.length > 0 ? (
+          <ul className="space-y-2">
+            {notes.map((evt) => (
+              <li key={evt.id} className="rounded border p-2">
+                <div className="text-sm text-gray-500">
+                  {new Date(evt.created_at).toLocaleString()}
+                </div>
+                {evt.note && <div className="text-sm">{evt.note}</div>}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No notes yet.</p>
+        )}
+      </section>
+
       <section>
         <h2 className="mb-2 font-semibold">Timeline</h2>
-        {timeline && timeline.length > 0 ? (
+        {otherEvents.length > 0 ? (
           <ul className="space-y-2">
-            {timeline.map((evt) => (
+            {otherEvents.map((evt) => (
               <li key={evt.id} className="rounded border p-2">
                 <div className="text-sm text-gray-500">
                   {new Date(evt.created_at).toLocaleString()}

--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AddNoteForm({ plantId }: { plantId: string }) {
+  const [note, setNote] = useState("");
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!note.trim()) return;
+
+    await fetch("/api/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plant_id: plantId, type: "note", note }),
+    });
+
+    setNote("");
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        className="w-full rounded border p-2"
+        placeholder="Write a note..."
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <button type="submit" className="rounded bg-green-600 px-3 py-1 text-white">
+        Add Note
+      </button>
+    </form>
+  );
+}

--- a/supabase/events.sql
+++ b/supabase/events.sql
@@ -1,0 +1,21 @@
+-- Run this in Supabase SQL editor to set up events table
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.events (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid references public.plants(id) on delete cascade,
+  type text not null,
+  note text,
+  created_at timestamptz default now()
+);
+
+alter table public.events enable row level security;
+
+drop policy if exists "public read events" on public.events;
+create policy "public read events" on public.events
+  for select using (true);
+
+drop policy if exists "public write events" on public.events;
+create policy "public write events" on public.events
+  for insert with check (true);


### PR DESCRIPTION
## Summary
- add freeform notes section on plant detail pages
- expose POST /api/events to store plant events
- document notes feature and note the roadmap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a66ce2979c83249e414180afc15499