### PR TITLE
Document single-user auth fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Set the following environment variables in `.env.local` to connect to Supabase:
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
+### Authentication
+
+Flora currently runs in a single-user mode and skips Supabase Auth.  You can
+optionally set `NEXT_PUBLIC_SINGLE_USER_ID` to control which user ID is used
+in database queries.  See [docs/auth.md](docs/auth.md) for more details on the
+decision and future plans.
+
 ## Roadmap
 
 See [ROADMAP.md](ROADMAP.md) for planned and in‑progress work.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,5 +118,5 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 - [x] Wrap up Plant Detail timeline view
 - [x] Build Rooms + Plant List page
 - [x] Add `/app/today` for task view
-- [ ] Evaluate Supabase Auth vs hardcoded single-user fallback
+- [x] Evaluate Supabase Auth vs hardcoded single-user fallback
 - [ ] Polish visual style, typography, and interactions

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,14 @@
+# Authentication Approach
+
+Flora currently operates as a single-user application without full Supabase Auth.
+
+## Evaluation
+
+- **Supabase Auth**: Provides secure user management and session handling but adds configuration overhead during early development.
+- **Hardcoded single-user fallback**: Keeps setup minimal by bypassing sign-in flows, suitable while the app targets a single caretaker.
+
+Given Flora's single-user focus at this stage, we chose the hardcoded fallback. Supabase Auth can be integrated later when multi-user support is needed.
+
+## Current Implementation
+
+The app reads a single user ID from the `NEXT_PUBLIC_SINGLE_USER_ID` environment variable (defaulting to `"flora-single-user"`).  This value is exposed via `src/lib/auth.ts` and can be used to scope database queries.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the current user id.
+ *
+ * Flora is currently single-user, so this is a hardcoded fallback until
+ * Supabase Auth is added.
+ */
+export const SINGLE_USER_ID =
+  process.env.NEXT_PUBLIC_SINGLE_USER_ID ?? "flora-single-user";
+
+export function getCurrentUserId() {
+  return SINGLE_USER_ID;
+}


### PR DESCRIPTION
## Summary
- document auth approach and decision to use a single-user fallback
- expose a helper for retrieving the fallback user id
- mark roadmap task complete and describe auth in README

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a66dff4bd08324a896e86d2f6f881d