### PR TITLE
feat: suggest existing rooms when adding plants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 ## Features
 
-- Add plants with species autosuggest.
+- Add plants with species autosuggest and room suggestions.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
 - Jot down freeform notes on each plant's detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
   - [ ] Optional photo upload
 
 - [ ] **Place**
-  - [ ] Room selector or creator
+  - [x] Room selector or creator
 
 - [ ] **Describe**
   - [ ] Pot size + material

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import SpeciesAutosuggest from "@/components/SpeciesAutosuggest";
 
 export default function AddPlantForm() {
   const [name, setName] = useState("");
   const [species, setSpecies] = useState("");
-  const [commonName, setCommonName] = useState(""); // 👈
+  const [commonName, setCommonName] = useState("");
   const [room, setRoom] = useState("");
+  const [rooms, setRooms] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch("/api/rooms")
+      .then((res) => res.json())
+      .then((data) => setRooms(data.data || []))
+      .catch((err) => console.error("Failed to load rooms:", err));
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,7 +51,7 @@ export default function AddPlantForm() {
           value={species}
           onSelect={(scientificName: string, common?: string) => {
             setSpecies(scientificName);
-            setCommonName(common || ""); // 👈 auto-fill
+            setCommonName(common || "");
           }}
         />
       </div>
@@ -52,9 +60,15 @@ export default function AddPlantForm() {
         <label>Room</label>
         <input
           type="text"
+          list="room-options"
           value={room}
           onChange={(e) => setRoom(e.target.value)}
         />
+        <datalist id="room-options">
+          {rooms.map((r) => (
+            <option key={r} value={r} />
+          ))}
+        </datalist>
       </div>
 
       <div>
@@ -62,7 +76,7 @@ export default function AddPlantForm() {
         <input
           type="text"
           value={commonName}
-          onChange={(e) => setCommonName(e.target.value)} // 👈 editable override
+          onChange={(e) => setCommonName(e.target.value)}
         />
       </div>
 
@@ -70,3 +84,4 @@ export default function AddPlantForm() {
     </form>
   );
 }
+

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function GET() {
+  try {
+    const { data, error } = await supabase
+      .from("plants")
+      .select("room")
+      .not("room", "is", null)
+      .neq("room", "");
+
+    if (error) throw error;
+
+    const rooms = Array.from(new Set((data ?? []).map((r) => r.room as string))).sort();
+
+    return NextResponse.json({ data: rooms });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("GET /rooms error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/rooms` endpoint to fetch distinct room names
- enhance Add Plant form with room suggestions via datalist
- document feature and check off roadmap task

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6703fdcfc8324895e0ce5db1b8bb8