### PR TITLE
Add pot size and material fields for plants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 ## Features
 
-- Add plants with species autosuggest, room suggestions, and optional photo uploads.
+- Add plants with species autosuggest, room suggestions, optional photo uploads, and pot size/material fields.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
 - Jot down freeform notes on each plant's detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
   - [x] Room selector or creator
 
 - [ ] **Describe**
-  - [ ] Pot size + material
+  - [x] Pot size + material
   - [ ] Light level
   - [ ] Drainage quality
   - [ ] Soil type

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -9,6 +9,8 @@ export default function AddPlantForm() {
   const [commonName, setCommonName] = useState("");
   const [room, setRoom] = useState("");
   const [rooms, setRooms] = useState<string[]>([]);
+  const [potSize, setPotSize] = useState("");
+  const [potMaterial, setPotMaterial] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
 
   useEffect(() => {
@@ -26,6 +28,8 @@ export default function AddPlantForm() {
     formData.append("species", species);
     formData.append("common_name", commonName);
     formData.append("room", room);
+    formData.append("pot_size", potSize);
+    formData.append("pot_material", potMaterial);
     if (photo) {
       formData.append("photo", photo);
     }
@@ -40,6 +44,8 @@ export default function AddPlantForm() {
       setSpecies("");
       setCommonName("");
       setRoom("");
+      setPotSize("");
+      setPotMaterial("");
       setPhoto(null);
     }
   };
@@ -88,6 +94,27 @@ export default function AddPlantForm() {
           onChange={(e) => setCommonName(e.target.value)}
           className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
         />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="mb-1 block text-sm font-medium">Pot Size</label>
+          <input
+            type="text"
+            value={potSize}
+            onChange={(e) => setPotSize(e.target.value)}
+            className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Pot Material</label>
+          <input
+            type="text"
+            value={potMaterial}
+            onChange={(e) => setPotMaterial(e.target.value)}
+            className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+          />
+        </div>
       </div>
 
       <div>

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -16,6 +16,8 @@ export async function POST(req: Request) {
     const species = formData.get("species") as string;
     const common_name = formData.get("common_name") as string | null;
     const room = formData.get("room") as string | null;
+    const pot_size = formData.get("pot_size") as string | null;
+    const pot_material = formData.get("pot_material") as string | null;
     const care_plan = formData.get("care_plan");
     let image_url: string | undefined;
 
@@ -47,6 +49,8 @@ export async function POST(req: Request) {
           species,
           common_name,
           room,
+          pot_size,
+          pot_material,
           care_plan,
           image_url,
         },

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -8,6 +8,8 @@ type Plant = {
   name: string;
   species: string | null;
   common_name: string | null;
+  pot_size: string | null;
+  pot_material: string | null;
   image_url: string | null;
 };
 
@@ -26,7 +28,7 @@ export default async function PlantDetailPage({ params }: { params: { id: string
 
   const { data: plant, error: plantError } = await supabase
     .from("plants")
-    .select("id, name, species, common_name, image_url")
+    .select("id, name, species, common_name, pot_size, pot_material, image_url")
     .eq("id", params.id)
     .single<Plant>();
 
@@ -61,6 +63,14 @@ export default async function PlantDetailPage({ params }: { params: { id: string
         )}
         {plant.species && (
           <p className="text-sm italic text-gray-600">{plant.species}</p>
+        )}
+        {plant.pot_size && (
+          <p className="text-sm text-gray-600">Pot size: {plant.pot_size}</p>
+        )}
+        {plant.pot_material && (
+          <p className="text-sm text-gray-600">
+            Pot material: {plant.pot_material}
+          </p>
         )}
       </div>
 

--- a/src/types/plant.ts
+++ b/src/types/plant.ts
@@ -1,7 +1,7 @@
 export type Plant = {
   name: string;
   species: string;
-  pot: string;
+  potSize: string;
   potMaterial: string;
   light: string;
   indoor: 'Indoor' | 'Outdoor';

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -10,6 +10,8 @@ create table if not exists public.plants (
   species text not null,
   room text,
   common_name text,
+  pot_size text,
+  pot_material text,
   image_url text,
   care_plan jsonb,
   created_at timestamptz default now()
@@ -19,6 +21,8 @@ create table if not exists public.plants (
 alter table if exists public.plants add column if not exists room text;
 alter table if exists public.plants add column if not exists common_name text;
 alter table if exists public.plants add column if not exists image_url text;
+alter table if exists public.plants add column if not exists pot_size text;
+alter table if exists public.plants add column if not exists pot_material text;
 
 -- Species table
 create table if not exists public.species (


### PR DESCRIPTION
## Summary
- allow recording pot size and material when adding a plant
- display pot details on plant pages
- document pot fields and update roadmap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a673d110548324bc22374120229bf2