### PR TITLE
Add light level field to plant form

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 ## Features
 
-- Add plants with species autosuggest, room suggestions, optional photo uploads, and pot size/material fields.
+- Add plants with species autosuggest, room suggestions, optional photo uploads, and pot size/material/light level fields.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
 - Jot down freeform notes on each plant's detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,8 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 > Goal: “From curious plant person to confident caretaker — in under a minute.”
 
 - [ ] **Identify**
-  - [ ] Plant nickname
-  - [ ] Species autosuggest (Perenual API)
+  - [x] Plant nickname
+  - [x] Species autosuggest (Perenual API)
   - [x] Optional photo upload
 
 - [ ] **Place**
@@ -29,7 +29,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [ ] **Describe**
   - [x] Pot size + material
-  - [ ] Light level
+  - [x] Light level
   - [ ] Drainage quality
   - [ ] Soil type
   - [ ] Indoor/outdoor

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -11,6 +11,7 @@ export default function AddPlantForm() {
   const [rooms, setRooms] = useState<string[]>([]);
   const [potSize, setPotSize] = useState("");
   const [potMaterial, setPotMaterial] = useState("");
+  const [lightLevel, setLightLevel] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
 
   useEffect(() => {
@@ -30,6 +31,7 @@ export default function AddPlantForm() {
     formData.append("room", room);
     formData.append("pot_size", potSize);
     formData.append("pot_material", potMaterial);
+    formData.append("light_level", lightLevel);
     if (photo) {
       formData.append("photo", photo);
     }
@@ -46,6 +48,7 @@ export default function AddPlantForm() {
       setRoom("");
       setPotSize("");
       setPotMaterial("");
+      setLightLevel("");
       setPhoto(null);
     }
   };
@@ -115,6 +118,20 @@ export default function AddPlantForm() {
             className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
           />
         </div>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium">Light Level</label>
+        <select
+          value={lightLevel}
+          onChange={(e) => setLightLevel(e.target.value)}
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+        >
+          <option value="">Select</option>
+          <option value="Low">Low</option>
+          <option value="Medium">Medium</option>
+          <option value="Bright">Bright</option>
+        </select>
       </div>
 
       <div>

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -18,6 +18,7 @@ export async function POST(req: Request) {
     const room = formData.get("room") as string | null;
     const pot_size = formData.get("pot_size") as string | null;
     const pot_material = formData.get("pot_material") as string | null;
+    const light_level = formData.get("light_level") as string | null;
     const care_plan = formData.get("care_plan");
     let image_url: string | undefined;
 
@@ -51,6 +52,7 @@ export async function POST(req: Request) {
           room,
           pot_size,
           pot_material,
+          light_level,
           care_plan,
           image_url,
         },

--- a/src/types/plant.ts
+++ b/src/types/plant.ts
@@ -3,7 +3,7 @@ export type Plant = {
   species: string;
   potSize: string;
   potMaterial: string;
-  light: string;
+  lightLevel: string;
   indoor: 'Indoor' | 'Outdoor';
   drainage: string;
   soil: string;

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -12,6 +12,7 @@ create table if not exists public.plants (
   common_name text,
   pot_size text,
   pot_material text,
+  light_level text,
   image_url text,
   care_plan jsonb,
   created_at timestamptz default now()
@@ -23,6 +24,7 @@ alter table if exists public.plants add column if not exists common_name text;
 alter table if exists public.plants add column if not exists image_url text;
 alter table if exists public.plants add column if not exists pot_size text;
 alter table if exists public.plants add column if not exists pot_material text;
+alter table if exists public.plants add column if not exists light_level text;
 
 -- Species table
 create table if not exists public.species (


### PR DESCRIPTION
## Summary
- capture plant light level during add flow and persist to Supabase
- update SQL schema and types for new light_level
- document new field and progress in README and roadmap

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a675781cc083248b9c26c04ebbc1f3