### PR TITLE
feat: track indoor or outdoor plants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 ## Features
 
-- Add plants with species autosuggest, room suggestions, optional photo uploads, and pot size/material/light level/drainage/soil fields.
+- Add plants with species autosuggest, room suggestions, optional photo uploads, and pot size/material/light level/drainage/soil/indoor–outdoor fields.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a timeline of care events.
 - Jot down freeform notes on each plant's detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
   - [x] Light level
   - [x] Drainage quality
   - [x] Soil type
-  - [ ] Indoor/outdoor
+  - [x] Indoor/outdoor
   - [ ] Local humidity + lat/lon (for climate context)
 
 - [ ] **Care Plan**

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -14,6 +14,7 @@ export default function AddPlantForm() {
   const [drainage, setDrainage] = useState("");
   const [soilType, setSoilType] = useState("");
   const [lightLevel, setLightLevel] = useState("");
+  const [indoor, setIndoor] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
 
   useEffect(() => {
@@ -36,6 +37,7 @@ export default function AddPlantForm() {
     formData.append("drainage", drainage);
     formData.append("soil_type", soilType);
     formData.append("light_level", lightLevel);
+    formData.append("indoor", indoor);
     if (photo) {
       formData.append("photo", photo);
     }
@@ -55,6 +57,7 @@ export default function AddPlantForm() {
       setDrainage("");
       setSoilType("");
       setLightLevel("");
+      setIndoor("");
       setPhoto(null);
     }
   };
@@ -148,6 +151,19 @@ export default function AddPlantForm() {
           onChange={(e) => setSoilType(e.target.value)}
           className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
         />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium">Location</label>
+        <select
+          value={indoor}
+          onChange={(e) => setIndoor(e.target.value)}
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+        >
+          <option value="">Select</option>
+          <option value="Indoor">Indoor</option>
+          <option value="Outdoor">Outdoor</option>
+        </select>
       </div>
 
       <div>

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -21,6 +21,7 @@ export async function POST(req: Request) {
     const drainage = formData.get("drainage") as string | null;
     const soil_type = formData.get("soil_type") as string | null;
     const light_level = formData.get("light_level") as string | null;
+    const indoor = formData.get("indoor") as string | null;
     const care_plan = formData.get("care_plan");
     let image_url: string | undefined;
 
@@ -57,6 +58,7 @@ export async function POST(req: Request) {
           drainage,
           soil_type,
           light_level,
+          indoor,
           care_plan,
           image_url,
         },

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -13,6 +13,7 @@ type Plant = {
   drainage: string | null;
   soil_type: string | null;
   image_url: string | null;
+  indoor: string | null;
 };
 
 type PlantEvent = {
@@ -37,8 +38,8 @@ export default async function PlantDetailPage({
   const { data: plant, error: plantError } = await supabase
     .from("plants")
 
-    .select("id, name, species, common_name, pot_size, pot_material, drainage, soil_type, image_url")
-    .eq("id", params.id)
+    .select("id, name, species, common_name, pot_size, pot_material, drainage, soil_type, image_url, indoor")
+    .eq("id", id)
 
     .single<Plant>();
 
@@ -87,6 +88,9 @@ export default async function PlantDetailPage({
         )}
         {plant.soil_type && (
           <p className="text-sm text-gray-600">Soil type: {plant.soil_type}</p>
+        )}
+        {plant.indoor && (
+          <p className="text-sm text-gray-600">Location: {plant.indoor}</p>
         )}
       </div>
 

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -15,6 +15,7 @@ create table if not exists public.plants (
   drainage text,
   soil_type text,
   light_level text,
+  indoor text,
   image_url text,
   care_plan jsonb,
   created_at timestamptz default now()
@@ -29,6 +30,7 @@ alter table if exists public.plants add column if not exists pot_material text;
 alter table if exists public.plants add column if not exists drainage text;
 alter table if exists public.plants add column if not exists soil_type text;
 alter table if exists public.plants add column if not exists light_level text;
+alter table if exists public.plants add column if not exists indoor text;
 
 -- Species table
 create table if not exists public.species (


### PR DESCRIPTION
## Summary
- allow selecting indoor or outdoor when adding a plant
- persist environment in database and show it on plant detail view
- document new option and update roadmap

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a678af1c088324a8fa796bd1044584