### PR TITLE
Add AI care plan generation to plant creation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Open a plant to see its detail page with a timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - Check today's care tasks on `/today`.
+- Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 
 ## Development

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,8 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
   - [x] Indoor/outdoor
   - [x] Local humidity + lat/lon (for climate context)
 
-- [ ] **Care Plan**
-  - [ ] Call `/api/ai-care` to get AI-generated defaults (watering interval, amount, fertilizer needs)
+- [x] **Care Plan**
+   - [x] Call `/api/ai-care` to get AI-generated defaults (watering interval, amount, fertilizer needs)
  
 
 - [ ] **Confirm**


### PR DESCRIPTION
## Summary
- fetch `/api/ai-care` to generate default plant care plan during add flow
- display suggested watering and fertilizing guidance before saving
- document feature and mark roadmap item complete

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a67b39dfa483249f0178971dbbc83d