### PR TITLE
feat: show success toast after saving plant

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Check today's care tasks on `/today`.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
+- Saving a plant now shows a success toast and redirects to its detail page.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,9 +39,9 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
    - [x] Call `/api/ai-care` to get AI-generated defaults (watering interval, amount, fertilizer needs)
  
 
-- [ ] **Confirm**
-  - [ ] Save plant to Supabase
-  - [ ] Show success toast + redirect to detail view
+  - [x] **Confirm**
+    - [x] Save plant to Supabase
+    - [x] Show success toast + redirect to detail view
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
+    "react-hot-toast": "^2.6.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@19.1.0)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -1094,6 +1097,11 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1569,6 +1577,13 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3048,6 +3063,10 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3492,6 +3511,13 @@ snapshots:
   react-hook-form@7.62.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  react-hot-toast@2.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-is@16.13.1: {}
 

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
 import SpeciesAutosuggest from "@/components/SpeciesAutosuggest";
 
 export default function AddPlantForm() {
@@ -29,6 +31,7 @@ export default function AddPlantForm() {
     | null
   >(null);
   const [loadingCare, setLoadingCare] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     fetch("/api/rooms")
@@ -116,6 +119,7 @@ export default function AddPlantForm() {
     });
 
     if (res.ok) {
+      const { data } = await res.json();
       setName("");
       setSpecies("");
       setCommonName("");
@@ -128,6 +132,13 @@ export default function AddPlantForm() {
       setIndoor("");
       setPhoto(null);
       setCarePlan(null);
+      toast.success("Plant saved!");
+      const id = data?.[0]?.id;
+      if (id) {
+        router.push(`/plants/${id}`);
+      }
+    } else {
+      toast.error("Failed to save plant");
     }
   };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
+import ToasterProvider from "@/components/ToasterProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -13,6 +14,7 @@ export default function RootLayout({
       <body
         className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased`}
       >
+        <ToasterProvider />
         <main className="mx-auto max-w-screen-md p-4">{children}</main>
       </body>
     </html>

--- a/src/components/ToasterProvider.tsx
+++ b/src/components/ToasterProvider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Toaster } from "react-hot-toast";
+
+export default function ToasterProvider() {
+  return <Toaster position="top-center" />;
+}


### PR DESCRIPTION
## Summary
- save plant flow now displays a toast notification and redirects to the new plant detail page
- add React Hot Toast provider in the app layout
- document confirmation flow and mark roadmap task complete

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a67c9ce320832480d4d8fb2e0cfda1