### PR TITLE
feat: add plant detail hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 - Add plants with species autosuggest, room suggestions, optional photo uploads, pot size/material/light level/drainage/soil/indoor–outdoor fields, and automatic geolocation + local humidity capture.
 - Assign plants to rooms and view them grouped by room.
-- Open a plant to see its detail page with a timeline of care events.
+- Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - Check today's care tasks on `/today`.
 - Generate an AI-powered care plan when creating a plant.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 > A visually rich, emotionally resonant view of each plant.
 
-- [ ] Photo + Name hero section
+- [x] Photo + Name hero section
 - [ ] Quick Stats: care plan values, last watered, next due
 - [x] Timeline of logged events (watering, fertilizing, notes)
 - [x] Notes section (freeform journaling)

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -61,19 +61,25 @@ export default async function PlantDetailPage({
   return (
     <div className="space-y-6 p-4">
       <div>
-        {plant.image_url && (
-          <img
-            src={plant.image_url}
-            alt={plant.name}
-            className="mb-4 w-full max-w-xs rounded"
-          />
-        )}
-        <h1 className="text-2xl font-bold">{plant.name}</h1>
-        {plant.common_name && (
-          <p className="text-gray-600">{plant.common_name}</p>
-        )}
-        {plant.species && (
-          <p className="text-sm italic text-gray-600">{plant.species}</p>
+        {plant.image_url ? (
+          <div className="relative mb-4">
+            <img
+              src={plant.image_url}
+              alt={plant.name}
+              className="h-48 w-full rounded object-cover"
+            />
+            <div className="absolute bottom-0 left-0 w-full bg-black/50 p-4">
+              <h1 className="text-2xl font-bold text-white">{plant.name}</h1>
+              {plant.common_name && (
+                <p className="text-sm text-white">{plant.common_name}</p>
+              )}
+              {plant.species && (
+                <p className="text-xs italic text-gray-200">{plant.species}</p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <h1 className="mb-4 text-2xl font-bold">{plant.name}</h1>
         )}
         {plant.pot_size && (
           <p className="text-sm text-gray-600">Pot size: {plant.pot_size}</p>


### PR DESCRIPTION
## Summary
- add hero section displaying plant photo and name on detail page
- document photo hero in README
- mark plant detail hero section complete in roadmap

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a67dbfd698832493d8e5db1b339c14