### PR TITLE
fix: import toast as named export

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import toast from "react-hot-toast";
+import { toast } from "react-hot-toast";
 import SpeciesAutosuggest from "@/components/SpeciesAutosuggest";
 
 export default function AddPlantForm() {


### PR DESCRIPTION
## Summary
- import toast as a named export to ensure React can resolve `react-hot-toast`

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a67df051d88324a72d914a2dee30db