### PR TITLE
feat: show plant quick stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Assign plants to rooms and view them grouped by room.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
+- See quick stats for each plant's care plan, including watering schedule and last/next watering dates.
 - Check today's care tasks on `/today`.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 > A visually rich, emotionally resonant view of each plant.
 
 - [x] Photo + Name hero section
-- [ ] Quick Stats: care plan values, last watered, next due
+- [x] Quick Stats: care plan values, last watered, next due
 - [x] Timeline of logged events (watering, fertilizing, notes)
 - [x] Notes section (freeform journaling)
 - [ ] Photo gallery


### PR DESCRIPTION
## Summary
- show quick stats on plant detail page including watering schedule and last/next watering
- document quick stats feature in README
- mark quick stats task complete in roadmap

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e96cb9c83248235be13c8475520