### PR TITLE
feat: add empty state CTA on plant list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 - Add plants with species autosuggest, room suggestions, optional photo uploads, pot size/material/light level/drainage/soil/indoor–outdoor fields, and automatic geolocation + local humidity capture.
 - Assign plants to rooms and view them grouped by room.
+- If you have no plants yet, a friendly CTA helps you add your first one.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - See quick stats for each plant's care plan, including watering schedule and last/next watering dates.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 ## 📋 Phase 3 – Plants List
 
 - [ ] Room view: show each room and its plants as image tiles
-- [ ] Empty state CTA: “Add your first plant”
+- [x] Empty state CTA: “Add your first plant”
 - [ ] Grid or list toggle 
 - [ ] Tap = go to plant detail
 

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -69,7 +69,15 @@ export default async function PlantsPage() {
           </section>
         ))
       ) : (
-        <p>No plants saved yet.</p>
+        <div className="text-center">
+          <p className="mb-4">No plants saved yet.</p>
+          <Link
+            href="/add"
+            className="inline-block rounded bg-green-600 px-4 py-2 text-white transition-colors hover:bg-green-700"
+          >
+            Add your first plant
+          </Link>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add link to add first plant when list is empty
- document feature in README
- mark roadmap task complete

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a67f7e43c48324aaef51bc4da21538