### PR TITLE
feat: add grid view toggle for plant list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 
 - Add plants with species autosuggest, room suggestions, optional photo uploads, pot size/material/light level/drainage/soil/indoor–outdoor fields, and automatic geolocation + local humidity capture.
 - Assign plants to rooms and view them grouped by room.
+- Toggle between list and grid views when browsing plants.
 - If you have no plants yet, a friendly CTA helps you add your first one.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,10 +60,10 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 ## 📋 Phase 3 – Plants List
 
-- [ ] Room view: show each room and its plants as image tiles
+- [x] Room view: show each room and its plants as image tiles
 - [x] Empty state CTA: “Add your first plant”
-- [ ] Grid or list toggle 
-- [ ] Tap = go to plant detail
+- [x] Grid or list toggle
+- [x] Tap = go to plant detail
 
 ---
 

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { createClient } from "@supabase/supabase-js";
+import PlantList from "@/components/PlantList";
 
 export const revalidate = 0;
 
@@ -9,6 +10,7 @@ type Plant = {
   room: string | null;
   species: string | null;
   common_name: string | null;
+  image_url: string | null;
 };
 
 export default async function PlantsPage() {
@@ -19,7 +21,7 @@ export default async function PlantsPage() {
 
   const { data, error } = await supabase
     .from("plants")
-    .select("id, name, room, species, common_name")
+    .select("id, name, room, species, common_name, image_url")
     .order("room")
     .order("name");
 
@@ -34,40 +36,7 @@ export default async function PlantsPage() {
     <div>
       <h1 className="mb-4 text-2xl font-bold">Plants</h1>
       {plants && plants.length > 0 ? (
-        Object.entries(
-          plants.reduce((acc: Record<string, Plant[]>, plant) => {
-            const room = plant.room || "Unassigned";
-            acc[room] = acc[room] || [];
-            acc[room].push(plant);
-            return acc;
-          }, {})
-        ).map(([room, plants]) => (
-          <section key={room} className="mb-8">
-            <h2 className="mb-2 text-xl font-semibold">{room}</h2>
-            <ul className="space-y-4">
-              {plants.map((plant) => (
-                <li key={plant.id}>
-                  <Link
-                    href={`/plants/${plant.id}`}
-                    className="block rounded border p-4"
-                  >
-                    <div className="font-semibold">{plant.name}</div>
-                    {plant.common_name && (
-                      <div className="text-sm text-gray-600">
-                        {plant.common_name}
-                      </div>
-                    )}
-                    {plant.species && (
-                      <div className="text-sm italic text-gray-600">
-                        {plant.species}
-                      </div>
-                    )}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))
+        <PlantList plants={plants} />
       ) : (
         <div className="text-center">
           <p className="mb-4">No plants saved yet.</p>

--- a/src/components/PlantList.tsx
+++ b/src/components/PlantList.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export type Plant = {
+  id: string;
+  name: string;
+  room: string | null;
+  species: string | null;
+  common_name: string | null;
+  image_url: string | null;
+};
+
+export default function PlantList({ plants }: { plants: Plant[] }) {
+  const [view, setView] = useState<"list" | "grid">("list");
+
+  const grouped = plants.reduce((acc: Record<string, Plant[]>, plant) => {
+    const room = plant.room || "Unassigned";
+    acc[room] = acc[room] || [];
+    acc[room].push(plant);
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-end">
+        <button
+          onClick={() => setView(view === "list" ? "grid" : "list")}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          {view === "list" ? "Grid view" : "List view"}
+        </button>
+      </div>
+      {Object.entries(grouped).map(([room, plants]) => (
+        <section key={room} className="mb-8">
+          <h2 className="mb-2 text-xl font-semibold">{room}</h2>
+          {view === "list" ? (
+            <ul className="space-y-4">
+              {plants.map((plant) => (
+                <li key={plant.id}>
+                  <Link
+                    href={`/plants/${plant.id}`}
+                    className="block rounded border p-4"
+                  >
+                    <div className="font-semibold">{plant.name}</div>
+                    {plant.common_name && (
+                      <div className="text-sm text-gray-600">
+                        {plant.common_name}
+                      </div>
+                    )}
+                    {plant.species && (
+                      <div className="text-sm italic text-gray-600">
+                        {plant.species}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+              {plants.map((plant) => (
+                <li key={plant.id}>
+                  <Link
+                    href={`/plants/${plant.id}`}
+                    className="block overflow-hidden rounded border"
+                  >
+                    {plant.image_url ? (
+                      <img
+                        src={plant.image_url}
+                        alt={plant.name}
+                        className="h-32 w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-32 items-center justify-center bg-gray-100 text-gray-500">
+                        {plant.name}
+                      </div>
+                    )}
+                    <div className="p-2 text-center text-sm font-medium">
+                      {plant.name}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client PlantList component with list/grid view toggle
- fetch plant images and use new component on plant listing page
- update roadmap and README to reflect the new toggle

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a68040672c8324b5ad0d32301f4980