### PR TITLE
feat: allow editing care plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - See quick stats for each plant's care plan, including watering schedule and last/next watering dates.
+- Edit a plant's care plan from its detail page.
 - Check today's care tasks on `/today`.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 - [x] Timeline of logged events (watering, fertilizing, notes)
 - [x] Notes section (freeform journaling)
 - [ ] Photo gallery
-- [ ] Edit button for care plan
+- [x] Edit button for care plan
 
 ---
 

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    const { care_plan } = await req.json();
+    const { data, error } = await supabase
+      .from("plants")
+      .update({ care_plan })
+      .eq("id", id)
+      .select();
+    if (error) throw error;
+    return NextResponse.json({ data });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("PATCH /plants/[id] error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/plants/[id]/edit/page.tsx
+++ b/src/app/plants/[id]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { createClient } from "@supabase/supabase-js";
+import EditCarePlanForm from "@/components/EditCarePlanForm";
+
+export const revalidate = 0;
+
+export default async function EditCarePlanPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: plant, error } = await supabase
+    .from("plants")
+    .select("id, care_plan")
+    .eq("id", id)
+    .single();
+
+  if (error || !plant) {
+    console.error("Error fetching plant:", error?.message);
+    return <div>Failed to load plant.</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Edit Care Plan</h1>
+      <EditCarePlanForm plantId={plant.id} initialCarePlan={plant.care_plan} />
+    </div>
+  );
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import AddNoteForm from "@/components/AddNoteForm";
+import Link from "next/link";
 
 export const revalidate = 0;
 
@@ -122,7 +123,10 @@ export default async function PlantDetailPage({
       </div>
 
       <section>
-        <h2 className="mb-2 font-semibold">Quick Stats</h2>
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="font-semibold">Quick Stats</h2>
+          <Link href={`/plants/${plant.id}/edit`} className="text-sm text-green-700 hover:underline">Edit</Link>
+        </div>
         {plant.care_plan ? (
           <ul className="space-y-1 text-sm">
             {plant.care_plan.waterEvery && (

--- a/src/components/EditCarePlanForm.tsx
+++ b/src/components/EditCarePlanForm.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function EditCarePlanForm({
+  plantId,
+  initialCarePlan,
+}: {
+  plantId: string;
+  initialCarePlan: {
+    waterEvery?: string;
+    fertEvery?: string;
+    fertFormula?: string;
+  } | null;
+}) {
+  const router = useRouter();
+  const [waterEvery, setWaterEvery] = useState(initialCarePlan?.waterEvery || "");
+  const [fertEvery, setFertEvery] = useState(initialCarePlan?.fertEvery || "");
+  const [fertFormula, setFertFormula] = useState(initialCarePlan?.fertFormula || "");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/plants/${plantId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        care_plan: {
+          waterEvery: waterEvery || undefined,
+          fertEvery: fertEvery || undefined,
+          fertFormula: fertFormula || undefined,
+        },
+      }),
+    });
+    router.push(`/plants/${plantId}`);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="mb-1 block text-sm font-medium">Water every</label>
+        <input
+          type="text"
+          value={waterEvery}
+          onChange={(e) => setWaterEvery(e.target.value)}
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-sm font-medium">Fertilize every</label>
+        <input
+          type="text"
+          value={fertEvery}
+          onChange={(e) => setFertEvery(e.target.value)}
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-sm font-medium">Fertilizer formula</label>
+        <input
+          type="text"
+          value={fertFormula}
+          onChange={(e) => setFertFormula(e.target.value)}
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+        />
+      </div>
+      <button
+        type="submit"
+        className="rounded bg-green-600 px-4 py-2 text-white transition-colors hover:bg-green-700"
+      >
+        Save Care Plan
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add edit care plan link to plant detail page and form to update care schedule
- support updating care plan via new API endpoint
- document new capability and roadmap status

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6817c5a8c8324b9c3af742a6efb09