### PR TITLE
feat: categorize tasks in today view

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Upload additional photos and view them in a gallery on each plant's detail page.
 - See quick stats for each plant's care plan, including watering schedule and last/next watering dates.
 - Edit a plant's care plan from its detail page.
-- Check today's care tasks on `/today`.
+- Review overdue, today, and upcoming care tasks on `/today`.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,8 +69,8 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 ## 📅 Phase 4 – Care Task Dashboard
 
-- [ ] “Today” view: show plants needing care today
-- [ ] Show overdue, due today, and upcoming
+- [x] “Today” view: show plants needing care today
+- [x] Show overdue, due today, and upcoming
 - [ ] Swipe to mark as done and swipe to snooze
 
 


### PR DESCRIPTION
## Summary
- categorize care tasks into overdue, today, and upcoming on `/today`
- document task view capabilities and update roadmap

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6835930d083248f615b1689b8c7da