### PR TITLE
Specify Node runtime for API routes using Supabase

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,4 +1,5 @@
 // src/app/api/plants/route.ts
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 

--- a/src/app/api/species/route.ts
+++ b/src/app/api/species/route.ts
@@ -1,4 +1,5 @@
 // src/app/api/species/route.ts
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 
 async function fetchPerenual(q: string) {


### PR DESCRIPTION
## Summary
- ensure Next.js API routes using Supabase run on the Node.js runtime by exporting `runtime = "nodejs"`

## Testing
- `pnpm lint`
- `curl -i -X POST http://localhost:3001/api/events`
- `curl -i http://localhost:3001/api/rooms`
- `curl -i http://localhost:3001/api/plants`
- `curl -i http://localhost:3001/api/species?q=rose`


------
https://chatgpt.com/codex/tasks/task_e_68a683b7404c83249608e7a13e182637