### PR TITLE
feat: complete tasks with swipe actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - See quick stats for each plant's care plan, including watering schedule and last/next watering dates.
 - Edit a plant's care plan from its detail page.
 - Review overdue, today, and upcoming care tasks on `/today`.
+- Swipe a task right to mark it done or left to snooze it on the Today page.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [x] “Today” view: show plants needing care today
 - [x] Show overdue, due today, and upcoming
-- [ ] Swipe to mark as done and swipe to snooze
+- [x] Swipe to mark as done and swipe to snooze
 
 
 ---

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
+  const { action, days } = await req.json();
+
+  try {
+    if (action === "complete") {
+      const { error } = await supabase
+        .from("tasks")
+        .update({ completed_at: new Date().toISOString() })
+        .eq("id", id);
+      if (error) throw error;
+    } else if (action === "snooze") {
+      const addDays = typeof days === "number" ? days : 1;
+      const { data, error: fetchError } = await supabase
+        .from("tasks")
+        .select("due_date")
+        .eq("id", id)
+        .single();
+      if (fetchError) throw fetchError;
+      const due = new Date(data.due_date);
+      due.setDate(due.getDate() + addDays);
+      const { error } = await supabase
+        .from("tasks")
+        .update({ due_date: due.toISOString().slice(0, 10) })
+        .eq("id", id);
+      if (error) throw error;
+    } else {
+      return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("PATCH /api/tasks/:id error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,13 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
+import TaskItem, { Task } from "@/components/TaskItem";
 
 export const revalidate = 0;
-
-type Task = {
-  id: string;
-  type: string;
-  due_date: string;
-  plant: { id: string; name: string }[];
-};
 
 export default async function TodayPage() {
   const supabase = createClient(
@@ -33,20 +27,9 @@ export default async function TodayPage() {
 
   const renderTasks = (list: Task[]) => (
     <ul className="space-y-4">
-      {list.map((task) => {
-        const plant = task.plant?.[0];
-        return (
-          <li key={task.id} className="rounded border p-4">
-            <div className="font-semibold">{task.type}</div>
-            {plant && (
-              <div className="text-sm text-gray-600">{plant.name}</div>
-            )}
-            {task.due_date !== today && (
-              <div className="text-xs text-gray-500">{task.due_date}</div>
-            )}
-          </li>
-        );
-      })}
+      {list.map((task) => (
+        <TaskItem key={task.id} task={task} today={today} />
+      ))}
     </ul>
   );
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+
+type PlantInfo = { id: string; name: string };
+export type Task = {
+  id: string;
+  type: string;
+  due_date: string;
+  plant: PlantInfo[];
+};
+
+export default function TaskItem({ task, today }: { task: Task; today: string }) {
+  const router = useRouter();
+  const touchStartX = useRef<number | null>(null);
+
+  const handleComplete = async () => {
+    await fetch(`/api/tasks/${task.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "complete" }),
+    });
+    router.refresh();
+  };
+
+  const handleSnooze = async () => {
+    await fetch(`/api/tasks/${task.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "snooze" }),
+    });
+    router.refresh();
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    // swipe threshold of 50px
+    if (deltaX > 50) {
+      handleComplete();
+    } else if (deltaX < -50) {
+      handleSnooze();
+    }
+    touchStartX.current = null;
+  };
+
+  const plant = task.plant?.[0];
+
+  return (
+    <li
+      className="rounded border p-4"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      <div className="font-semibold">{task.type}</div>
+      {plant && <div className="text-sm text-gray-600">{plant.name}</div>}
+      {task.due_date !== today && (
+        <div className="text-xs text-gray-500">{task.due_date}</div>
+      )}
+      <div className="mt-2 flex gap-2 text-sm">
+        <button
+          onClick={handleComplete}
+          className="rounded bg-green-600 px-2 py-1 text-white"
+        >
+          Done
+        </button>
+        <button
+          onClick={handleSnooze}
+          className="rounded bg-gray-300 px-2 py-1"
+        >
+          Snooze
+        </button>
+      </div>
+    </li>
+  );
+}
+


### PR DESCRIPTION
## Summary
- enable marking tasks done or snoozing via swipe gestures
- add API route to complete or snooze tasks
- document new task actions and update roadmap

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6845340548324adeb5cd7edca3b28