### PR TITLE
feat: add basic route protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.
+- Optional HTTP Basic Auth to gate access when deploying.
 
 ## Development
 
@@ -33,6 +34,8 @@ Set the following environment variables in `.env.local` to connect to Supabase:
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- `BASIC_AUTH_USER` (optional)
+- `BASIC_AUTH_PASSWORD` (optional)
 
 Create a storage bucket named `plant-photos` in your Supabase project to store uploaded plant images.
 
@@ -43,7 +46,8 @@ Flora currently runs in a single-user mode and skips Supabase Auth. Set
 queries. Database rows in `plants` and `tasks` are now protected with
 row-level security scoped to this ID, so be sure to run the SQL setup files in
 `supabase/` on your project. See [docs/auth.md](docs/auth.md) for more details
-on the decision and future plans.
+on the decision and future plans. When `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD`
+are set, all routes are protected with simple HTTP Basic Auth.
 
 ## Roadmap
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 ---
 
 - [x] Add Row-Level Security (RLS) to `plants` and `tasks`
-- [ ] Protect routes (e.g. `/app`)
+- [x] Protect routes (e.g. `/app`)
 
 ---
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -12,3 +12,10 @@ Given Flora's single-user focus at this stage, we chose the hardcoded fallback. 
 ## Current Implementation
 
 The app reads a single user ID from the `NEXT_PUBLIC_SINGLE_USER_ID` environment variable (defaulting to `"flora-single-user"`). This value is exposed via `src/lib/auth.ts`, stored in `user_id` columns on tables like `plants` and `tasks`, and enforced by Supabase row-level security policies.
+
+## Route Protection
+
+For deployments, routes can be gated with simple HTTP Basic Auth. Set the
+`BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` environment variables to require a
+username and password for all pages. Leaving these unset disables the auth
+layer, which is useful for local development.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const expectedUser = process.env.BASIC_AUTH_USER;
+  const expectedPassword = process.env.BASIC_AUTH_PASSWORD;
+
+  // Skip auth if credentials are not set
+  if (!expectedUser || !expectedPassword) {
+    return NextResponse.next();
+  }
+
+  const basicAuth = req.headers.get("authorization");
+
+  if (basicAuth) {
+    const authValue = basicAuth.split(" ")[1];
+    const [user, password] = atob(authValue).split(":");
+    if (user === expectedUser && password === expectedPassword) {
+      return NextResponse.next();
+    }
+  }
+
+  return new NextResponse("Authentication required", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Secure Area"',
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary
- add middleware to gate all routes with HTTP Basic Auth when credentials are provided
- document BASIC_AUTH_* env vars and mark roadmap task complete

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a68880a6b883248af55c3e2609456b