### PR TITLE
Add plant data export endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.
 - Optional HTTP Basic Auth to gate access when deploying.
+- Export your plant data in JSON or CSV via `/api/export?format=csv`.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,7 +104,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 ## 📦  Backup & Export
 
-- [ ] Export all plant data to JSON or CSV
+- [x] Export all plant data to JSON or CSV
 - [ ] Import feature for recovery
 
 ---

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "@/lib/auth";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+function toCsv<T extends Record<string, unknown>>(rows: T[]): string {
+  if (!rows.length) return "";
+  const headers = Object.keys(rows[0]);
+  const escape = (val: unknown) => {
+    if (val === null || val === undefined) return "";
+    return `"${String(val).replace(/"/g, '""')}"`;
+  };
+  const lines = [
+    headers.join(","),
+    ...rows.map((row) =>
+      headers.map((h) => escape(row[h as keyof T])).join(","),
+    ),
+  ];
+  return lines.join("\n");
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const format = searchParams.get("format") ?? "json";
+
+    const { data, error } = await supabase
+      .from("plants")
+      .select("*")
+      .eq("user_id", getCurrentUserId())
+      .order("name");
+
+    if (error) throw error;
+
+    if (format === "csv") {
+      const csv = toCsv(data);
+      return new NextResponse(csv, {
+        headers: {
+          "Content-Type": "text/csv",
+          "Content-Disposition": "attachment; filename=plants.csv",
+        },
+      });
+    }
+
+    return NextResponse.json({ data });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/export` endpoint to download plant data in JSON or CSV format
- document export capability in README and roadmap

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a689c8683083249f644c95b9b6941b