### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.
+- Switch between light and dark themes with a simple toggle.
 - Optional HTTP Basic Auth to gate access when deploying.
 - Export your plant data in JSON or CSV via `/api/export?format=csv`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 ## 🧪 Phase 7 – Polish & UX
 
 - [ ] Mobile layout refinements
-- [ ] Dark mode toggle
+ - [x] Dark mode toggle
 - [ ] Animations (task done, photo upload, etc.)
 - [ ] Cache API calls + loading states
 - [ ] Micro-interactions (emoji feedback, care badges)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
     "next": "15.5.0",
+    "next-themes": "0.2.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       next:
         specifier: 15.5.0
         version: 15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: 0.2.1
+        version: 0.2.1(next@15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1445,6 +1448,13 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-themes@0.2.1:
+    resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
+    peerDependencies:
+      next: '*'
+      react: '*'
+      react-dom: '*'
 
   next@15.5.0:
     resolution: {integrity: sha512-N1lp9Hatw3a9XLt0307lGB4uTKsXDhyOKQo7uYMzX4i0nF/c27grcGXkLdb7VcT8QPYLBa8ouIyEoUQJ2OyeNQ==}
@@ -3372,6 +3382,12 @@ snapshots:
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
+
+  next-themes@0.2.1(next@15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      next: 15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next@15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import ToasterProvider from "@/components/ToasterProvider";
+import ThemeToggle from "@/components/ThemeToggle";
+import { ThemeProvider } from "next-themes";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -12,10 +14,15 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased`}
+        className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100`}
       >
-        <ToasterProvider />
-        <main className="mx-auto max-w-screen-md p-4">{children}</main>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+          <ToasterProvider />
+          <header className="flex justify-end p-4">
+            <ThemeToggle />
+          </header>
+          <main className="mx-auto max-w-screen-md p-4">{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="rounded border px-2 py-1 text-sm dark:border-gray-600"
+    >
+      {theme === 'dark' ? 'Light' : 'Dark'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add dark mode toggle component using next-themes
- document dark mode in README and ROADMAP

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a68aa05b308324a69617e5ab820be6