### PR TITLE
fix: use valid uuid for default user id

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,10 +2,12 @@
  * Returns the current user id.
  *
  * Flora is currently single-user, so this is a hardcoded fallback until
- * Supabase Auth is added.
+ * Supabase Auth is added. The fallback must be a valid UUID so that queries
+ * against columns typed as `uuid` do not error.
  */
 export const SINGLE_USER_ID =
-  process.env.NEXT_PUBLIC_SINGLE_USER_ID ?? "flora-single-user";
+  process.env.NEXT_PUBLIC_SINGLE_USER_ID ??
+  "00000000-0000-0000-0000-000000000000";
 
 export function getCurrentUserId() {
   return SINGLE_USER_ID;


### PR DESCRIPTION
## Summary
- ensure single-user fallback id is a valid UUID

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68a5549848324be9ddb87d874b4f9