### PR TITLE
feat: add plant import endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Switch between light and dark themes with a simple toggle.
 - Optional HTTP Basic Auth to gate access when deploying.
 - Export your plant data in JSON or CSV via `/api/export?format=csv`.
+- Restore plant data by POSTing exported JSON to `/api/import`.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 ## 📦  Backup & Export
 
 - [x] Export all plant data to JSON or CSV
-- [ ] Import feature for recovery
+- [x] Import feature for recovery
 
 ---
 

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "@/lib/auth";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => null);
+    const rows = Array.isArray(body) ? body : body?.data;
+
+    if (!Array.isArray(rows)) {
+      return NextResponse.json(
+        { error: "Expected JSON array or { data: [...] }" },
+        { status: 400 },
+      );
+    }
+
+    const userId = getCurrentUserId();
+    const cleaned = rows.map((row: Record<string, unknown>) => {
+      const { id, created_at, user_id, ...rest } = row as Record<string, unknown>; // eslint-disable-line @typescript-eslint/no-unused-vars
+      return { ...rest, user_id: userId };
+    });
+
+    const { error } = await supabase.from("plants").insert(cleaned);
+    if (error) throw error;
+
+    return NextResponse.json({ inserted: cleaned.length });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/import` route to restore plants from JSON
- document import support in README and ROADMAP

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a68bde50188324853ec82a7b0b91fd