### PR TITLE
feat: cache data and add loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Edit a plant's care plan from its detail page.
 - Review overdue, today, and upcoming care tasks on `/today`.
 - Swipe a task right to mark it done or left to snooze it on the Today page.
+- Cached data fetching with friendly loading states on list pages.
 - Generate an AI-powered care plan when creating a plant.
 - Polished UI with Inter typography and improved form interactions.
 - Saving a plant now shows a success toast and redirects to its detail page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 - [ ] Mobile layout refinements
  - [x] Dark mode toggle
 - [ ] Animations (task done, photo upload, etc.)
-- [ ] Cache API calls + loading states
+ - [x] Cache API calls + loading states
 - [ ] Micro-interactions (emoji feedback, care badges)
 
 ---

--- a/src/app/plants/loading.tsx
+++ b/src/app/plants/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading plants...</p>;
+}

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
-import { createClient } from "@supabase/supabase-js";
 import PlantList from "@/components/PlantList";
-import { getCurrentUserId } from "@/lib/auth";
+import { getPlants } from "@/lib/data";
 
 export const revalidate = 0;
 
@@ -15,22 +14,11 @@ type Plant = {
 };
 
 export default async function PlantsPage() {
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
-
-  const { data, error } = await supabase
-    .from("plants")
-    .select("id, name, room, species, common_name, image_url")
-    .eq("user_id", getCurrentUserId())
-    .order("room")
-    .order("name");
-
-  const plants = data as Plant[] | null;
-
-  if (error) {
-    console.error("Error fetching plants:", error.message);
+  let plants: Plant[] | null = null;
+  try {
+    plants = (await getPlants()) as Plant[] | null;
+  } catch (error) {
+    console.error("Error fetching plants:", error);
     return <div>Failed to load plants.</div>;
   }
 

--- a/src/app/today/loading.tsx
+++ b/src/app/today/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading tasks...</p>;
+}

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,24 +1,15 @@
-import { createClient } from "@supabase/supabase-js";
 import TaskItem, { Task } from "@/components/TaskItem";
-import { getCurrentUserId } from "@/lib/auth";
+import { getTasks } from "@/lib/data";
 
 export const revalidate = 0;
 
 export default async function TodayPage() {
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
-
   const today = new Date().toISOString().slice(0, 10);
-  const { data, error } = await supabase
-    .from("tasks")
-    .select("id, type, due_date, plant:plants(id, name)")
-    .eq("user_id", getCurrentUserId())
-    .order("due_date");
-
-  if (error) {
-    console.error("Error fetching tasks:", error.message);
+  let data;
+  try {
+    data = await getTasks();
+  } catch (error) {
+    console.error("Error fetching tasks:", error);
     return <div>Failed to load tasks.</div>;
   }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,32 @@
+import { cache } from "react";
+import { supabaseAdmin } from "./supabaseAdmin";
+import { getCurrentUserId } from "./auth";
+
+export const getPlants = cache(async () => {
+  const { data, error } = await supabaseAdmin
+    .from("plants")
+    .select("id, name, room, species, common_name, image_url")
+    .eq("user_id", getCurrentUserId())
+    .order("room")
+    .order("name");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+});
+
+export const getTasks = cache(async () => {
+  const { data, error } = await supabaseAdmin
+    .from("tasks")
+    .select("id, type, due_date, plant:plants(id, name)")
+    .eq("user_id", getCurrentUserId())
+    .order("due_date");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+});


### PR DESCRIPTION
## Summary
- cache Supabase queries for plants and tasks
- add loading indicators for plant list and task dashboard
- document new caching behavior in README and Roadmap

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68cc927088324bf3d61018ff098cc