### PR TITLE
refactor: move theme provider to client component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import ToasterProvider from "@/components/ToasterProvider";
 import ThemeToggle from "@/components/ThemeToggle";
-import { ThemeProvider } from "next-themes";
+import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,13 +16,13 @@ export default function RootLayout({
       <body
         className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100`}
       >
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+        <Providers>
           <ToasterProvider />
           <header className="flex justify-end p-4">
             <ThemeToggle />
           </header>
           <main className="mx-auto max-w-screen-md p-4">{children}</main>
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { ThemeProvider } from "next-themes";
+import type { ReactNode } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+      {children}
+    </ThemeProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move ThemeProvider usage into new client-side Providers component
- update root layout to wrap content with Providers

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d3c17e88324a72ea8663b639e47