### PR TITLE
Add sample plants and tasks seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Set the following environment variables in `.env.local` to connect to Supabase:
 
 Create a storage bucket named `plant-photos` in your Supabase project to store uploaded plant images.
 
+### Sample data
+
+To quickly try Flora with some example plants and tasks, run the SQL in
+[`supabase/sample_data.sql`](supabase/sample_data.sql) against your Supabase
+database after creating the tables.
+
 ### Authentication
 
 Flora currently runs in a single-user mode and skips Supabase Auth. Set

--- a/supabase/sample_data.sql
+++ b/supabase/sample_data.sql
@@ -1,0 +1,18 @@
+-- Sample data for plants and tasks
+-- Run this in Supabase SQL editor after creating tables
+
+-- Insert sample plants
+insert into public.plants (id, user_id, name, species, common_name, room)
+values
+  ('11111111-1111-1111-1111-111111111111', 'flora-single-user', 'Aloe Vera', 'Aloe vera', 'Aloe', 'Living Room'),
+  ('22222222-2222-2222-2222-222222222222', 'flora-single-user', 'Fiddle Leaf Fig', 'Ficus lyrata', 'Fiddle Leaf Fig', 'Office'),
+  ('33333333-3333-3333-3333-333333333333', 'flora-single-user', 'Monstera', 'Monstera deliciosa', 'Swiss Cheese Plant', 'Bedroom')
+on conflict (id) do nothing;
+
+-- Insert sample tasks (overdue, due today, upcoming)
+insert into public.tasks (id, plant_id, user_id, type, due_date)
+values
+  ('aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1', '11111111-1111-1111-1111-111111111111', 'flora-single-user', 'Water', current_date - interval '1 day'),
+  ('aaaaaaa2-aaaa-aaaa-aaaa-aaaaaaaaaaa2', '22222222-2222-2222-2222-222222222222', 'flora-single-user', 'Fertilize', current_date),
+  ('aaaaaaa3-aaaa-aaaa-aaaa-aaaaaaaaaaa3', '33333333-3333-3333-3333-333333333333', 'flora-single-user', 'Repot', current_date + interval '3 day')
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- seed database with sample plants and tasks for demo purposes
- document optional sample data seed in README

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68f0c1774832482a46f8e2d9ada58