### PR TITLE
feat: add species API caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Export your plant data in JSON or CSV via `/api/export?format=csv`.
 - Restore plant data by POSTing exported JSON to `/api/import`.
 
+## Rate limits and caching
+
+Species suggestions are fetched from third-party APIs that may enforce rate
+limits. The `/api/species` endpoint keeps a short-lived in-memory cache keyed by
+query string to avoid hitting those limits repeatedly.
+
 ## Development
 
 Install dependencies and start the development server:


### PR DESCRIPTION
## Summary
- cache species lookup responses in-memory with a TTL
- note external API rate limits and caching in the docs

## Testing
- `pnpm lint src/app/api/species/route.ts README.md`


------
https://chatgpt.com/codex/tasks/task_e_68a695e5e4f08324a04dc0363468aea5