### PR TITLE
Add dynamic care plan item to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,6 +87,8 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
   - [x] Real weather data
   - [x] Climate zone inference
   - [ ] Historical behavior
+- [ ] Dynamic care plan updates
+  - Re-run AI-care weekly or when humidity, season, or repeated snoozes suggest adjustments
 - [x] “Care coach” suggestions on plant detail page
 - [ ] Timeline trend insights (“you’ve watered 5 days late lately…”)
 

--- a/src/app/api/plants/route.test.ts
+++ b/src/app/api/plants/route.test.ts
@@ -1,38 +1,41 @@
-import { test } from "node:test";
-import { strict as assert } from "node:assert";
+import { describe, it, expect } from "vitest";
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
 
-test("plantSchema validates correct payload", async () => {
-  const { plantSchema } = await import("./route");
-  const result = plantSchema.safeParse({
-    name: "Fern",
-    species: "Pteridophyta",
-    latitude: 40,
-    longitude: -70,
-    humidity: 50,
+describe("plants API route", () => {
+  it("plantSchema validates correct payload", async () => {
+    const { plantSchema } = await import("./route");
+    const result = plantSchema.safeParse({
+      name: "Fern",
+      species: "Pteridophyta",
+      latitude: 40,
+      longitude: -70,
+      humidity: 50,
+    });
+    expect(result.success).toBe(true);
   });
-  assert.equal(result.success, true);
+
+  it("POST returns 400 for invalid latitude", async () => {
+    const { POST } = await import("./route");
+    const form = new FormData();
+    form.set("name", "Fern");
+    form.set("species", "Pteridophyta");
+    form.set("latitude", "200");
+    const req = new Request("http://localhost", { method: "POST", body: form });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("plantSchema rejects invalid latitude", async () => {
+    const { plantSchema } = await import("./route");
+    const result = plantSchema.safeParse({
+      name: "Fern",
+      species: "Pteridophyta",
+      latitude: 200,
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
-test("POST returns 400 for invalid latitude", async () => {
-  const { POST } = await import("./route");
-  const form = new FormData();
-  form.set("name", "Fern");
-  form.set("species", "Pteridophyta");
-  form.set("latitude", "200");
-  const req = new Request("http://localhost", { method: "POST", body: form });
-  const res = await POST(req);
-  assert.equal(res.status, 400);
-});
-
-test("plantSchema rejects invalid latitude", async () => {
-  const { plantSchema } = await import("./route");
-  const result = plantSchema.safeParse({
-    name: "Fern",
-    species: "Pteridophyta",
-    latitude: 200,
-  });
-  assert.equal(result.success, false);
-});
+export {};

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
-import { getCurrentUserId } from "@/lib/auth";
+import { getCurrentUserId } from "../../../lib/auth";
 import { z } from "zod";
 
 const supabase = createClient(


### PR DESCRIPTION
## Summary
- document dynamic care plan updates driven by humidity, season, and repeated snoozes
- migrate plants API tests to Vitest and fix auth import path for compatibility

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a697f03bfc8324a041bc598e0ed610