### PR TITLE
refactor: simplify plant route params

### DIFF
--- a/src/app/plants/[id]/edit/page.tsx
+++ b/src/app/plants/[id]/edit/page.tsx
@@ -7,9 +7,9 @@ export const revalidate = 0;
 export default async function EditCarePlanPage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }) {
-  const { id } = await params;
+  const { id } = params;
 
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -43,9 +43,9 @@ type PlantEvent = {
 export default async function PlantDetailPage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }) {
-  const { id } = await params;
+  const { id } = params;
 
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- simplify plant detail and edit page params to use plain object instead of Promise

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6993dbac4832488cd685842e808a4