### PR TITLE
Add API validation tests for plants and events routes

### DIFF
--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => "user-123",
+}));
+
+vi.mock("@/lib/cloudinary", () => ({
+  uploader: { upload_stream: () => ({ end: () => {} }) },
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "plants") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { id: "1" }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "events") {
+        return {
+          insert: () => ({
+            select: () => Promise.resolve({ data: [{ id: "1" }], error: null }),
+          }),
+        };
+      }
+      return {} as any;
+    },
+  }),
+}));
+
+describe("POST /api/events", () => {
+  it("returns 200 for valid submission", async () => {
+    const { POST } = await import("../src/app/api/events/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plant_id: "1", type: "water" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const { POST } = await import("../src/app/api/events/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plant_id: "1" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid field types", async () => {
+    const { POST } = await import("../src/app/api/events/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plant_id: 0, type: "water" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("../src/lib/auth", () => ({
+  getCurrentUserId: () => "user-123",
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      insert: () => ({
+        select: () => Promise.resolve({ data: [{ id: "1" }], error: null }),
+      }),
+    }),
+  }),
+}));
+
+describe("POST /api/plants", () => {
+  it("returns 200 for valid submission", async () => {
+    const { POST } = await import("../src/app/api/plants/route");
+    const form = new FormData();
+    form.set("name", "Fern");
+    form.set("species", "Pteridophyta");
+    const req = new Request("http://localhost", { method: "POST", body: form });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const { POST } = await import("../src/app/api/plants/route");
+    const form = new FormData();
+    form.set("species", "Pteridophyta");
+    const req = new Request("http://localhost", { method: "POST", body: form });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid field types", async () => {
+    const { POST } = await import("../src/app/api/plants/route");
+    const form = new FormData();
+    form.set("name", "Fern");
+    form.set("species", "Pteridophyta");
+    form.set("latitude", "not-a-number");
+    const req = new Request("http://localhost", { method: "POST", body: form });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for /api/plants covering valid submissions, missing fields, and invalid types
- add tests for /api/events covering valid submissions, missing fields, and invalid types

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a699408cdc8324a01718c98b2463c2