### PR TITLE
Validate event API payloads

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,69 +1,72 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
 import { getCurrentUserId } from "@/lib/auth";
 import cloudinary from "@/lib/cloudinary";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
+
+const allowedTypes = ["note", "photo"] as const;
+
+const fileMetadataSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  size: z.number().int().nonnegative(),
+});
+
+const eventSchema = z
+  .object({
+    plant_id: z.string().uuid(),
+    type: z.enum(allowedTypes),
+    note: z.string().optional(),
+    file: fileMetadataSchema.optional(),
+  })
+  .refine((data) => (data.type === "photo" ? !!data.file : true), {
+    message: "file is required when type is 'photo'",
+    path: ["file"],
+  });
 
 export async function POST(req: Request) {
   try {
     const contentType = req.headers.get("content-type") || "";
+    let parsed: z.infer<typeof eventSchema>;
+    let file: File | undefined;
 
     if (contentType.includes("multipart/form-data")) {
       const formData = await req.formData();
-      const plant_id = formData.get("plant_id") as string | null;
-      const type = (formData.get("type") as string | null) || "photo";
-      const note = formData.get("note") as string | null;
-
-      if (!plant_id || !type) {
-        return NextResponse.json(
-          { error: "plant_id and type are required" },
-          { status: 400 },
-        );
+      const maybeFile = formData.get("photo");
+      file = maybeFile instanceof File ? maybeFile : undefined;
+      try {
+        parsed = eventSchema.parse({
+          plant_id: formData.get("plant_id"),
+          type: formData.get("type"),
+          note: formData.get("note") ?? undefined,
+          file: file
+            ? { name: file.name, type: file.type, size: file.size }
+            : undefined,
+        });
+      } catch (err) {
+        const message = err instanceof z.ZodError ? err.flatten() : err;
+        return NextResponse.json({ error: message }, { status: 400 });
       }
-
-      const { error: plantCheckError } = await supabase
-        .from("plants")
-        .select("id")
-        .eq("id", plant_id)
-        .eq("user_id", getCurrentUserId())
-        .single();
-      if (plantCheckError) {
-        return NextResponse.json({ error: "Plant not found" }, { status: 404 });
+    } else {
+      const json = await req.json();
+      try {
+        parsed = eventSchema.parse(json);
+      } catch (err) {
+        const message = err instanceof z.ZodError ? err.flatten() : err;
+        return NextResponse.json({ error: message }, { status: 400 });
       }
-
-      let image_url: string | undefined;
-      const file = formData.get("photo");
-      if (file instanceof File) {
-        const buffer = Buffer.from(await file.arrayBuffer());
-        const uploadResult = await new Promise<import("cloudinary").UploadApiResponse>((resolve, reject) =>
-          cloudinary.uploader
-            .upload_stream({ folder: "plant-photos" }, (error, result) =>
-              error ? reject(error) : resolve(result!)
-            )
-            .end(buffer)
-        );
-        image_url = uploadResult.secure_url;
-      }
-
-      const { data, error } = await supabase
-        .from("events")
-        .insert([{ plant_id, type, note, image_url }])
-        .select();
-
-      if (error) throw error;
-      return NextResponse.json({ data });
     }
 
-    const body = await req.json();
-    const { plant_id, type, note } = body;
+    const { plant_id, type, note } = parsed;
 
-    if (!plant_id || !type) {
+    if (type === "photo" && !file) {
       return NextResponse.json(
-        { error: "plant_id and type are required" },
+        { error: "file upload required" },
         { status: 400 },
       );
     }
@@ -78,9 +81,22 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Plant not found" }, { status: 404 });
     }
 
+    let image_url: string | undefined;
+    if (file) {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const uploadResult = await new Promise<import("cloudinary").UploadApiResponse>((resolve, reject) =>
+        cloudinary.uploader
+          .upload_stream({ folder: "plant-photos" }, (error, result) =>
+            error ? reject(error) : resolve(result!)
+          )
+          .end(buffer)
+      );
+      image_url = uploadResult.secure_url;
+    }
+
     const { data, error } = await supabase
       .from("events")
-      .insert([{ plant_id, type, note }])
+      .insert([{ plant_id, type, note, image_url }])
       .select();
 
     if (error) throw error;
@@ -92,3 +108,4 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
+


### PR DESCRIPTION
## Summary
- add zod schema to validate plant_id, type, note, and file metadata
- support parsing multipart and JSON bodies with unified validation
- insert events using validated data and required file uploads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69930927c8324a627ef11046eb98d