### PR TITLE
feat: onboarding progress and care timeline visuals

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import AddNoteForm from "@/components/AddNoteForm";
 import AddPhotoForm from "@/components/AddPhotoForm";
+import CareTimeline from "@/components/CareTimeline";
 import Link from "next/link";
 import { getCurrentUserId } from "@/lib/auth";
 
@@ -227,8 +228,9 @@ export default async function PlantDetailPage({
 
       <section>
         <h2 className="mb-2 font-semibold">Timeline</h2>
+        <CareTimeline events={timeline ?? []} />
         {otherEvents.length > 0 ? (
-          <ul className="space-y-2">
+          <ul className="mt-4 space-y-2">
             {otherEvents.map((evt) => (
               <li key={evt.id} className="rounded border p-2">
                 <div className="text-sm text-gray-500">
@@ -240,7 +242,7 @@ export default async function PlantDetailPage({
             ))}
           </ul>
         ) : (
-          <p>No events logged yet.</p>
+          <p className="mt-4">No events logged yet.</p>
         )}
       </section>
     </div>

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,19 +1,25 @@
 import TaskItem, { Task } from "@/components/TaskItem";
-import { getTasks } from "@/lib/data";
+import OnboardingProgress from "@/components/OnboardingProgress";
+import EmptyStateCTA from "@/components/EmptyStateCTA";
+import { getTasks, getPlants } from "@/lib/data";
 
 export const revalidate = 0;
 
 export default async function TodayPage() {
   const today = new Date().toISOString().slice(0, 10);
   let data;
+  let plants;
   try {
     data = await getTasks();
+    plants = await getPlants();
   } catch (error) {
     console.error("Error fetching tasks:", error);
     return <div>Failed to load tasks.</div>;
   }
 
   const tasks = (data ?? []) as Task[];
+  const hasPlants = (plants ?? []).length > 0;
+  const hasTasks = tasks.length > 0;
   const overdue = tasks.filter((t) => t.due_date < today);
   const dueToday = tasks.filter((t) => t.due_date === today);
   const upcoming = tasks.filter((t) => t.due_date > today);
@@ -28,6 +34,7 @@ export default async function TodayPage() {
 
   return (
     <div>
+      <OnboardingProgress hasPlants={hasPlants} hasTasks={hasTasks} />
       <h1 className="mb-4 text-2xl font-bold">Today&apos;s Tasks</h1>
 
       {overdue.length > 0 && (
@@ -53,7 +60,7 @@ export default async function TodayPage() {
 
       {overdue.length === 0 &&
         dueToday.length === 0 &&
-        upcoming.length === 0 && <p>No tasks.</p>}
+        upcoming.length === 0 && <EmptyStateCTA />}
     </div>
   );
 }

--- a/src/components/CareTimeline.tsx
+++ b/src/components/CareTimeline.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+type CareEvent = {
+  id: string;
+  type: string;
+  created_at: string;
+};
+
+const typeColors: Record<string, string> = {
+  water: "bg-blue-500",
+  fertilize: "bg-yellow-500",
+  note: "bg-gray-500",
+  photo: "bg-green-500",
+};
+
+export default function CareTimeline({ events }: { events: CareEvent[] }) {
+  const [filter, setFilter] = useState<string>("all");
+  const types = Array.from(new Set(events.map((e) => e.type)));
+  const filtered =
+    filter === "all" ? events : events.filter((e) => e.type === filter);
+
+  return (
+    <div>
+      <div className="mb-2 flex space-x-2">
+        <button
+          onClick={() => setFilter("all")}
+          className={`rounded-full px-3 py-1 text-sm capitalize ${
+            filter === "all" ? "bg-green-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          all
+        </button>
+        {types.map((t) => (
+          <button
+            key={t}
+            onClick={() => setFilter(t)}
+            className={`rounded-full px-3 py-1 text-sm capitalize ${
+              filter === t ? "bg-green-600 text-white" : "bg-gray-200"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="flex space-x-4 overflow-x-auto py-2">
+        {filtered.map((e) => (
+          <div
+            key={e.id}
+            title={`${e.type} • ${new Date(e.created_at).toLocaleDateString()}`}
+            className={`h-4 w-4 rounded-full ${
+              typeColors[e.type] || "bg-gray-400"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/EmptyStateCTA.tsx
+++ b/src/components/EmptyStateCTA.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function EmptyStateCTA() {
+  return (
+    <div className="rounded border p-4 text-center">
+      <p className="mb-2">No tasks yet.</p>
+      <Link href="/add" className="text-green-700 underline">
+        Add your first plant
+      </Link>
+    </div>
+  );
+}

--- a/src/components/OnboardingProgress.tsx
+++ b/src/components/OnboardingProgress.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  hasPlants: boolean;
+  hasTasks: boolean;
+}
+
+type OnboardingState = {
+  addedPlant: boolean;
+  scheduledTask: boolean;
+  viewedToday: boolean;
+};
+
+export default function OnboardingProgress({ hasPlants, hasTasks }: Props) {
+  const [state, setState] = useState<OnboardingState>({
+    addedPlant: false,
+    scheduledTask: false,
+    viewedToday: false,
+  });
+
+  useEffect(() => {
+    const stored = JSON.parse(
+      typeof window !== "undefined"
+        ? localStorage.getItem("onboarding") || "{}"
+        : "{}",
+    );
+
+    const updated: OnboardingState = {
+      addedPlant: stored.addedPlant || hasPlants,
+      scheduledTask: stored.scheduledTask || hasTasks,
+      viewedToday: true,
+    };
+
+    setState(updated);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("onboarding", JSON.stringify(updated));
+    }
+  }, [hasPlants, hasTasks]);
+
+  const completed = Object.values(state).filter(Boolean).length;
+  const progress = Math.round((completed / 3) * 100);
+
+  if (completed === 3) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="mb-1 text-sm">
+        Onboarding {completed}/3 steps complete
+      </div>
+      <div className="h-2 w-full rounded bg-gray-200">
+        <div
+          className="h-2 rounded bg-green-600"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -19,7 +19,13 @@ vi.mock("@supabase/supabase-js", () => ({
           select: () => ({
             eq: () => ({
               eq: () => ({
-                single: () => Promise.resolve({ data: { id: "1" }, error: null }),
+                single: () =>
+                  Promise.resolve({
+                    data: {
+                      id: "123e4567-e89b-12d3-a456-426614174000",
+                    },
+                    error: null,
+                  }),
               }),
             }),
           }),
@@ -32,7 +38,7 @@ vi.mock("@supabase/supabase-js", () => ({
           }),
         };
       }
-      return {} as any;
+      return {} as Record<string, never>;
     },
   }),
 }));
@@ -43,7 +49,10 @@ describe("POST /api/events", () => {
     const req = new Request("http://localhost", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ plant_id: "1", type: "water" }),
+      body: JSON.stringify({
+        plant_id: "123e4567-e89b-12d3-a456-426614174000",
+        type: "note",
+      }),
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -65,7 +74,7 @@ describe("POST /api/events", () => {
     const req = new Request("http://localhost", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ plant_id: 0, type: "water" }),
+      body: JSON.stringify({ plant_id: "not-a-uuid", type: "note" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- show onboarding progress bar and CTA on empty Today page
- add interactive horizontal care timeline with filters on plant details
- adjust event API tests for stricter validation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6987f165c83249f9530837c4630d2