### PR TITLE
fix: include hookform resolvers dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.1",
+    "@hookform/resolvers": "5.2.1",
     "@supabase/supabase-js": "^2.55.0",
     "cloudinary": "^2.7.0",
     "next": "15.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^5.2.1
+        specifier: 5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       '@supabase/supabase-js':
         specifier: ^2.55.0


### PR DESCRIPTION
## Summary
- pin `@hookform/resolvers` to ensure `zod` resolver is available

## Testing
- `pnpm test`
- `pnpm build` *(fails: Turbopack could not fetch `Inter` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a69c5594f48324b2522fab18d23313