### PR TITLE
fix: include all headers in CSV export

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,6 +1,13 @@
 export function toCsv<T extends Record<string, unknown>>(rows: T[]): string {
   if (!rows.length) return "";
-  const headers = Object.keys(rows[0]);
+  // Collect a deterministic set of headers from all rows.
+  // Using only the first row could drop fields that appear in later rows.
+  const headers = Array.from(
+    rows.reduce((set, row) => {
+      Object.keys(row).forEach((key) => set.add(key));
+      return set;
+    }, new Set<string>())
+  );
   const escape = (val: unknown) => {
     if (val === null || val === undefined) return "";
     return `"${String(val).replace(/"/g, '""')}"`;

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -15,4 +15,16 @@ describe("toCsv", () => {
       'name,note,quote\n"Alice, Bob","Line1\nLine2","She said ""Hello"""'
     );
   });
+
+  it("includes headers from all rows", () => {
+    const rows = [
+      { a: 1, b: 2 },
+      { b: 3, c: 4 },
+    ];
+    const csv = toCsv(rows);
+    // The second column exists only on the first row and the first column exists
+    // only on the second row. Those missing values should still appear as empty
+    // cells in the CSV output.
+    expect(csv).toBe('a,b,c\n"1","2",\n,"3","4"');
+  });
 });


### PR DESCRIPTION
## Summary
- include headers from all data rows when generating CSV
- cover exported headers with new unit test

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69f04f280832485c471adc86c46db