### PR TITLE
feat: add navigation component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import ToasterProvider from "@/components/ToasterProvider";
 import ThemeToggle from "@/components/ThemeToggle";
+import Navigation from "@/components/Navigation";
 import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -18,7 +19,8 @@ export default function RootLayout({
       >
         <Providers>
           <ToasterProvider />
-          <header className="flex justify-end p-4">
+          <header className="flex items-center justify-between p-4">
+            <Navigation />
             <ThemeToggle />
           </header>
           <main className="mx-auto max-w-screen-md p-4">{children}</main>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const links = [
+  { href: '/today', label: 'Today' },
+  { href: '/plants', label: 'Plants' },
+  { href: '/add', label: 'Add' },
+];
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Main navigation">
+      <ul className="flex items-center gap-4 text-sm md:text-base">
+        {links.map(({ href, label }) => {
+          const isActive = pathname === href;
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`rounded px-2 py-1 hover:bg-green-200 dark:hover:bg-gray-700 ${
+                  isActive ? 'bg-green-300 font-semibold dark:bg-gray-600' : ''
+                }`}
+              >
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/tests/navigation.test.tsx
+++ b/tests/navigation.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import Navigation from '../src/components/Navigation';
+
+// Mock next/link to render a simple anchor
+vi.mock('next/link', () => ({
+  default: (
+    { href, children, ...props }: { href: string; children: React.ReactNode } & Record<string, unknown>,
+  ) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+let pathname = '/today';
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+}));
+
+describe('Navigation', () => {
+  it('renders links to all sections', () => {
+    const html = renderToString(<Navigation />);
+    expect(html).toContain('href="/today"');
+    expect(html).toContain('href="/plants"');
+    expect(html).toContain('href="/add"');
+  });
+
+  it('highlights the active route', () => {
+    pathname = '/plants';
+    const html = renderToString(<Navigation />);
+    expect(html).toMatch(/href="\/plants"[^>]*aria-current="page"/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Navigation component with links to Today, Plants, and Add and highlight active route
- include Navigation in layout header before ThemeToggle
- test navigation renders links and marks active path

## Testing
- `pnpm lint src/components/Navigation.tsx src/app/layout.tsx tests/navigation.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69faceedc83248cbc451f7a2a31e3