### PR TITLE
fix: refine text colors for dark theme

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -238,7 +238,7 @@ export default function AddPlantForm() {
       </div>
 
       {step === 1 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Identify</h2>
           <div>
             <label className="mb-1 block text-sm font-medium">Nickname</label>
@@ -292,7 +292,7 @@ export default function AddPlantForm() {
       )}
 
       {step === 2 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Place</h2>
           <div>
             <label className="mb-1 block text-sm font-medium">Room</label>
@@ -335,7 +335,7 @@ export default function AddPlantForm() {
       )}
 
       {step === 3 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Pot Setup</h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
@@ -379,7 +379,7 @@ export default function AddPlantForm() {
       )}
 
       {step === 4 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Environment</h2>
           <input type="hidden" {...register("latitude")} />
           <input type="hidden" {...register("longitude")} />
@@ -400,7 +400,7 @@ export default function AddPlantForm() {
       )}
 
       {step === 5 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Smart Plan</h2>
           <button
             type="button"
@@ -414,7 +414,7 @@ export default function AddPlantForm() {
             {loadingCare ? "Generating..." : "Generate Care Plan"}
           </button>
           {carePlan && (
-            <div className="mt-2 space-y-1 rounded border bg-white p-3 text-sm">
+            <div className="mt-2 space-y-1 rounded border bg-white p-3 text-sm text-gray-900 dark:text-gray-100">
               <p>Water every: {carePlan.waterEvery}</p>
               <p>Fertilize: {carePlan.fertEvery} ({carePlan.fertFormula})</p>
               {carePlan.weather && (
@@ -429,7 +429,7 @@ export default function AddPlantForm() {
       )}
 
       {step === 6 && (
-        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 shadow-sm">
+        <div className="space-y-4 rounded-xl border bg-gray-50 p-6 text-gray-900 dark:text-gray-100 shadow-sm">
           <h2 className="text-lg font-medium">Ready to add &lsquo;{nameValue}&rsquo;?</h2>
           <div className="space-y-2 text-sm">
             <p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,15 +16,15 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100`}
+        className={`${inter.className} min-h-dvh bg-green-50 text-gray-900 antialiased dark:bg-gray-900`}
       >
         <Providers>
           <ToasterProvider />
-          <header className="flex items-center justify-between p-4">
+          <header className="flex items-center justify-between p-4 text-gray-900 dark:text-gray-100">
             <Navigation />
             <ThemeToggle />
           </header>
-          <main className="mx-auto max-w-screen-md p-4">{children}</main>
+          <main className="mx-auto max-w-screen-md p-4 text-gray-900 dark:text-gray-100">{children}</main>
         </Providers>
       </body>
     </html>

--- a/src/components/SpeciesAutosuggest.tsx
+++ b/src/components/SpeciesAutosuggest.tsx
@@ -80,7 +80,7 @@ export default function SpeciesAutosuggest({ value, onSelect }: Props) {
       )}
 
       {results.length > 0 && (
-        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded border bg-white shadow-lg">
+        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded border bg-white text-gray-900 dark:text-gray-100 shadow-lg">
           {results.map((species) => (
             <li
               key={species.id}


### PR DESCRIPTION
## Summary
- remove global dark text color from layout and scope header & main text colors
- ensure step forms and autosuggest dropdown have explicit text colors across themes

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a6b5002c83249e67ab3f86f63d1c