### PR TITLE
Use shadcn form components in AddNoteForm

### DIFF
--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -2,10 +2,13 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { Form, Textarea, Button } from "@/components/ui";
 
 export default function AddNoteForm({ plantId }: { plantId: string }) {
   const [note, setNote] = useState("");
   const router = useRouter();
+  const form = useForm();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -22,19 +25,21 @@ export default function AddNoteForm({ plantId }: { plantId: string }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <textarea
-        className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
-        placeholder="Write a note..."
-        value={note}
-        onChange={(e) => setNote(e.target.value)}
-      />
-      <button
-        type="submit"
-        className="rounded bg-green-600 px-4 py-2 text-white transition-colors hover:bg-green-700"
-      >
-        Add Note
-      </button>
-    </form>
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Textarea
+          className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-600"
+          placeholder="Write a note..."
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <Button
+          type="submit"
+          className="rounded bg-green-600 px-4 py-2 text-white transition-colors hover:bg-green-700"
+        >
+          Add Note
+        </Button>
+      </form>
+    </Form>
   );
 }


### PR DESCRIPTION
## Summary
- refactor note form to leverage shadcn `Form` provider
- replace html `textarea`/`button` with `Textarea` and `Button` components

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6aace53d883248fc311e549819f39