### PR TITLE
Use async params in task route

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -9,9 +9,9 @@ const supabase = createClient(
 
 export async function PATCH(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const id = params.id;
+  const { id } = await params;
   const { action, days, reason } = await req.json();
 
   try {


### PR DESCRIPTION
## Summary
- refactor task API handler to await `params` for dynamic `id`
- confirm other dynamic API routes already await `params`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ab691b788324bb847507598dc644