### PR TITLE
feat: clarify drainage selection

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -389,16 +389,80 @@ export default function AddPlantForm() {
             </div>
           </div>
           <div>
-            <label className="mb-1 block text-sm font-medium">Drainage</label>
-            <select
-              {...register("drainage")}
-              className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
-            >
-              <option value="">Select</option>
-              <option value="Poor">💧 Poor</option>
-              <option value="Average">🪴 Average</option>
-              <option value="Good">🌿 Good</option>
-            </select>
+            <fieldset>
+              <legend className="mb-1 block text-sm font-medium">Drainage</legend>
+              <div className="space-y-2">
+                <div>
+                  <label
+                    htmlFor="drainage-poor"
+                    className="flex items-center gap-2"
+                    title="Water drains slowly; high risk of root rot"
+                  >
+                    <input
+                      type="radio"
+                      id="drainage-poor"
+                      value="Poor"
+                      {...register("drainage")}
+                      aria-label="Poor drainage"
+                      aria-describedby="drainage-poor-desc"
+                    />
+                    <span>💧 Poor</span>
+                  </label>
+                  <p
+                    id="drainage-poor-desc"
+                    className="ml-6 text-xs text-muted-foreground"
+                  >
+                    Water drains slowly; high risk of root rot
+                  </p>
+                </div>
+                <div>
+                  <label
+                    htmlFor="drainage-average"
+                    className="flex items-center gap-2"
+                    title="Standard drainage with moderate watering"
+                  >
+                    <input
+                      type="radio"
+                      id="drainage-average"
+                      value="Average"
+                      {...register("drainage")}
+                      aria-label="Average drainage"
+                      aria-describedby="drainage-average-desc"
+                    />
+                    <span>🪴 Average</span>
+                  </label>
+                  <p
+                    id="drainage-average-desc"
+                    className="ml-6 text-xs text-muted-foreground"
+                  >
+                    Standard drainage with moderate watering
+                  </p>
+                </div>
+                <div>
+                  <label
+                    htmlFor="drainage-good"
+                    className="flex items-center gap-2"
+                    title="Excellent drainage; water flows quickly"
+                  >
+                    <input
+                      type="radio"
+                      id="drainage-good"
+                      value="Good"
+                      {...register("drainage")}
+                      aria-label="Good drainage"
+                      aria-describedby="drainage-good-desc"
+                    />
+                    <span>🌿 Good</span>
+                  </label>
+                  <p
+                    id="drainage-good-desc"
+                    className="ml-6 text-xs text-muted-foreground"
+                  >
+                    Excellent drainage; water flows quickly
+                  </p>
+                </div>
+              </div>
+            </fieldset>
           </div>
           <div>
             <label className="mb-1 block text-sm font-medium">Soil Type</label>

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { renderToString } from "react-dom/server";
 
-(global as any).React = React;
+(globalThis as unknown as { React: typeof React }).React = React;
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
@@ -85,7 +85,7 @@ vi.mock("@supabase/supabase-js", () => ({
           }),
         };
       }
-      return {} as any;
+      return {} as Record<string, unknown>;
     },
   }),
 }));


### PR DESCRIPTION
## Summary
- replace drainage dropdown with radio button group and descriptive helper text
- add aria labels for each drainage choice and improve tooltips
- adjust tests to remove `any` types for linting

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc72ed888324b2b2dc976b337aff