### PR TITLE
Show water amount in plant care plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - Upload additional photos and view them in a gallery on each plant's detail page.
-- See quick stats for each plant's care plan, including watering schedule and last/next watering dates.
+- See quick stats for each plant's care plan, including watering schedule, water amount, and last/next watering dates.
 - Edit a plant's care plan from its detail page.
 - Get gentle Care Coach suggestions when a plant's watering is overdue.
 - Review overdue, today, and upcoming care tasks on `/today`.
@@ -20,7 +20,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Receive push notifications for due tasks via Supabase Edge Functions.
 - Enjoy a subtle fade-out animation when completing tasks.
 - Cached data fetching with friendly loading states on list pages.
-- Generate an AI-powered care plan when creating a plant.
+- Generate an AI-powered care plan when creating a plant, including watering amounts.
 - Care plan suggestions now factor in real-time local weather data.
 - Care plan suggestions now incorporate your climate zone.
 - Polished UI with Inter typography and improved form interactions.

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -9,6 +9,11 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import SpeciesAutosuggest from "@/components/SpeciesAutosuggest";
 
+function formatWaterAmount(ml: number) {
+  const oz = ml / 29.5735;
+  return `${oz.toFixed(1)} oz (${ml} mL)`;
+}
+
 const formSchema = z
   .object({
     name: z.string().min(1, "Plant name is required"),
@@ -44,6 +49,7 @@ export default function AddPlantForm() {
   const [rooms, setRooms] = useState<string[]>([]);
   interface CarePlan {
     waterEvery: string;
+    waterAmountMl: number;
     fertEvery: string;
     fertFormula: string;
     rationale: string;
@@ -558,6 +564,9 @@ export default function AddPlantForm() {
           {carePlan && (
             <div className="mt-2 space-y-1 rounded border bg-card p-3 text-sm text-foreground">
               <p>Water every: {carePlan.waterEvery}</p>
+              <p>
+                Water amount: {formatWaterAmount(carePlan.waterAmountMl)}
+              </p>
               <p>Fertilize: {carePlan.fertEvery} ({carePlan.fertFormula})</p>
               {carePlan.weather && (
                 <p>
@@ -584,7 +593,7 @@ export default function AddPlantForm() {
             )}
             {carePlan && (
               <p>
-                <strong>Care Plan:</strong> water {carePlan.waterEvery}, fertilize {carePlan.fertEvery}
+                <strong>Care Plan:</strong> water {carePlan.waterEvery} ({formatWaterAmount(carePlan.waterAmountMl)}), fertilize {carePlan.fertEvery}
               </p>
             )}
             {photoPreview && (

--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: Request) {
 
   let aiData: {
     waterEvery: string;
+    waterAmountMl: number;
     fertEvery: string;
     fertFormula: string;
     rationale: string;
@@ -51,7 +52,7 @@ export async function POST(req: Request) {
 
   if (process.env.OPENAI_API_KEY) {
     try {
-      const prompt = `You are a helpful gardening assistant. Based on the following data, provide watering and fertilizing guidance in JSON format with keys waterEvery, fertEvery, fertFormula, and rationale. The rationale must mention the plant species.
+      const prompt = `You are a helpful gardening assistant. Based on the following data, provide watering and fertilizing guidance in JSON format with keys waterEvery, waterAmountMl, fertEvery, fertFormula, and rationale. The rationale must mention the plant species. waterAmountMl must be a number representing the amount of water in milliliters needed each time the plant is watered.
 
 Species: ${species ?? "unknown"}
 Pot size: ${potSize ?? "unknown"}cm
@@ -85,6 +86,7 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
   if (!aiData) {
     aiData = {
       waterEvery: "7 days",
+      waterAmountMl: 250,
       fertEvery: "Monthly",
       fertFormula: "10-10-10",
       rationale: `General care guidance for ${species ?? "this plant"}.`,
@@ -103,6 +105,7 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
 
   return Response.json({
     waterEvery: aiData.waterEvery,
+    waterAmountMl: aiData.waterAmountMl,
     fertEvery: aiData.fertEvery,
     fertFormula: aiData.fertFormula,
     rationale,

--- a/src/app/api/species/route.test.ts
+++ b/src/app/api/species/route.test.ts
@@ -53,7 +53,7 @@ describe("species API route", () => {
       }
       throw new Error(`Unexpected fetch call: ${input}`);
     });
-    (global as any).fetch = fetchMock;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const { GET } = await import("./route");
     const req = new Request("http://localhost/api/species?q=rose");

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -21,8 +21,14 @@ import { getCurrentUserId } from "@/lib/auth";
 
 export const revalidate = 0;
 
+function formatWaterAmount(ml: number) {
+  const oz = ml / 29.5735;
+  return `${oz.toFixed(1)} oz (${ml} mL)`;
+}
+
 type CarePlan = {
   waterEvery?: string;
+  waterAmountMl?: number;
   fertEvery?: string;
   fertFormula?: string;
   rationale?: string;
@@ -181,6 +187,11 @@ export default async function PlantDetailPage({
                   <li>
                     <span className="font-medium">Water every:</span>{" "}
                     {plant.care_plan.waterEvery}
+                    {plant.care_plan.waterAmountMl && (
+                      <span className="block text-muted-foreground">
+                        {formatWaterAmount(plant.care_plan.waterAmountMl)}
+                      </span>
+                    )}
                     {lastWatered && (
                       <span className="block text-muted-foreground">
                         Last watered: {lastWatered.toLocaleDateString()}

--- a/src/components/EditCarePlanForm.tsx
+++ b/src/components/EditCarePlanForm.tsx
@@ -11,12 +11,16 @@ export default function EditCarePlanForm({
   plantId: string;
   initialCarePlan: {
     waterEvery?: string;
+    waterAmountMl?: number;
     fertEvery?: string;
     fertFormula?: string;
   } | null;
 }) {
   const router = useRouter();
   const [waterEvery, setWaterEvery] = useState(initialCarePlan?.waterEvery || "");
+  const [waterAmountMl, setWaterAmountMl] = useState(
+    initialCarePlan?.waterAmountMl ? String(initialCarePlan.waterAmountMl) : "",
+  );
   const [fertEvery, setFertEvery] = useState(initialCarePlan?.fertEvery || "");
   const [fertFormula, setFertFormula] = useState(initialCarePlan?.fertFormula || "");
 
@@ -28,6 +32,9 @@ export default function EditCarePlanForm({
       body: JSON.stringify({
         care_plan: {
           waterEvery: waterEvery || undefined,
+          waterAmountMl: waterAmountMl
+            ? Number(waterAmountMl)
+            : undefined,
           fertEvery: fertEvery || undefined,
           fertFormula: fertFormula || undefined,
         },
@@ -48,6 +55,17 @@ export default function EditCarePlanForm({
           type="text"
           value={waterEvery}
           onChange={(e) => setWaterEvery(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label htmlFor="water-amount" className="mb-1 block text-sm font-medium">
+          Water amount (mL)
+        </Label>
+        <Input
+          id="water-amount"
+          type="number"
+          value={waterAmountMl}
+          onChange={(e) => setWaterAmountMl(e.target.value)}
         />
       </div>
       <div>


### PR DESCRIPTION
## Summary
- include waterAmountMl in AI-generated care plan data
- display water amount (oz/mL) when adding or viewing plants
- allow editing water amount in care plan form

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bef854e483249d63ee3181e23e75