### PR TITLE
Clarify care plan edit link

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,6 +3,7 @@ import AddNoteForm from "@/components/AddNoteForm";
 import AddPhotoForm from "@/components/AddPhotoForm";
 import CareTimeline from "@/components/CareTimeline";
 import Link from "next/link";
+import { DropletIcon } from "lucide-react";
 import {
   Tabs,
   TabsList,
@@ -176,9 +177,11 @@ export default async function PlantDetailPage({
               <h2 className="font-semibold">Quick Stats</h2>
               <Link
                 href={`/plants/${plant.id}/edit`}
-                className="text-sm text-primary hover:underline"
+                className="flex items-center gap-1 text-sm text-primary hover:underline"
+                title="Only affects watering and fertilizer settings"
               >
-                Edit
+                <DropletIcon className="size-4 stroke-[1.5]" />
+                Edit Care Plan
               </Link>
             </div>
             {plant.care_plan ? (


### PR DESCRIPTION
## Summary
- clarify quick stats link text to "Edit Care Plan"
- add droplet icon and tooltip explaining only watering/fertilizer settings are affected

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0a87b508324bda540726361eb7c