### PR TITLE
feat: allow deleting photo events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - Open a plant to see its detail page with a photo hero and timeline of care events.
 - Jot down freeform notes on each plant's detail page.
 - Upload additional photos and view them in a gallery on each plant's detail page.
+- Remove unwanted photos from a plant's gallery.
 - See quick stats for each plant's care plan, including watering schedule, water amount, and last/next watering dates.
 - Edit a plant's care plan from its detail page.
 - Get gentle Care Coach suggestions when a plant's watering is overdue.

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "@/lib/auth";
+import cloudinary from "@/lib/cloudinary";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const { id } = params;
+    const { data: event, error: eventError } = await supabase
+      .from("events")
+      .select("id, plant_id, public_id")
+      .eq("id", id)
+      .single();
+    if (eventError || !event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+
+    const { error: authError } = await supabase
+      .from("plants")
+      .select("id")
+      .eq("id", event.plant_id)
+      .eq("user_id", getCurrentUserId())
+      .single();
+    if (authError) {
+      return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+    }
+
+    const { error: deleteError } = await supabase
+      .from("events")
+      .delete()
+      .eq("id", id);
+    if (deleteError) {
+      throw deleteError;
+    }
+
+    if (event.public_id) {
+      try {
+        await cloudinary.uploader.destroy(event.public_id);
+      } catch (err) {
+        console.error("Error deleting image from Cloudinary:", err);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("DELETE /events/[id] error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -81,23 +81,25 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Plant not found" }, { status: 404 });
     }
 
-    let image_url: string | undefined;
-    if (file) {
-      const buffer = Buffer.from(await file.arrayBuffer());
-      const uploadResult = await new Promise<import("cloudinary").UploadApiResponse>((resolve, reject) =>
-        cloudinary.uploader
-          .upload_stream({ folder: "plant-photos" }, (error, result) =>
-            error ? reject(error) : resolve(result!)
-          )
-          .end(buffer)
-      );
-      image_url = uploadResult.secure_url;
-    }
+  let image_url: string | undefined;
+  let public_id: string | undefined;
+  if (file) {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const uploadResult = await new Promise<import("cloudinary").UploadApiResponse>((resolve, reject) =>
+      cloudinary.uploader
+        .upload_stream({ folder: "plant-photos" }, (error, result) =>
+          error ? reject(error) : resolve(result!)
+        )
+        .end(buffer)
+    );
+    image_url = uploadResult.secure_url;
+    public_id = uploadResult.public_id;
+  }
 
-    const { data, error } = await supabase
-      .from("events")
-      .insert([{ plant_id, type, note, image_url }])
-      .select();
+  const { data, error } = await supabase
+    .from("events")
+    .insert([{ plant_id, type, note, image_url, public_id }])
+    .select();
 
     if (error) throw error;
 

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,7 +3,7 @@ import AddNoteForm from "@/components/AddNoteForm";
 import AddPhotoForm from "@/components/AddPhotoForm";
 import CareTimeline from "@/components/CareTimeline";
 import Link from "next/link";
-import { DropletIcon } from "lucide-react";
+import DeletePhotoButton from "@/components/DeletePhotoButton";
 import {
   Tabs,
   TabsList,
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui";
 import { getCurrentUserId } from "@/lib/auth";
+import type { Event as PlantEvent } from "@/types/event";
 
 export const revalidate = 0;
 
@@ -54,13 +55,6 @@ type Plant = {
   care_plan: CarePlan | null;
 };
 
-type PlantEvent = {
-  id: string;
-  type: string;
-  note: string | null;
-  image_url: string | null;
-  created_at: string;
-};
 
 export default async function PlantDetailPage({
   params,
@@ -90,7 +84,7 @@ export default async function PlantDetailPage({
 
   const { data: events } = await supabase
     .from("events")
-    .select("id, type, note, image_url, created_at")
+    .select("id, type, note, image_url, public_id, created_at")
     .eq("plant_id", id)
     .order("created_at", { ascending: false });
 
@@ -246,7 +240,7 @@ export default async function PlantDetailPage({
             {photoEvents.length > 0 ? (
               <div className="grid grid-cols-2 gap-2">
                 {photoEvents.map((evt) => (
-                  <div key={evt.id}>
+                  <div key={evt.id} className="relative">
                     {evt.image_url && (
                       <img
                         src={evt.image_url}
@@ -254,6 +248,7 @@ export default async function PlantDetailPage({
                         className="h-32 w-full rounded object-cover"
                       />
                     )}
+                    <DeletePhotoButton eventId={evt.id} />
                     {evt.note && (
                       <div className="text-xs text-muted-foreground">{evt.note}</div>
                     )}

--- a/src/components/DeletePhotoButton.tsx
+++ b/src/components/DeletePhotoButton.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2Icon } from "lucide-react";
+
+export default function DeletePhotoButton({ eventId }: { eventId: string }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    if (!confirm("Delete this photo?")) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/events/${eventId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to delete photo");
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="absolute right-1 top-1">
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={loading}
+        className="rounded bg-black/60 p-1 text-white hover:bg-black/80 disabled:opacity-50"
+        aria-label="Delete photo"
+      >
+        <Trash2Icon className="h-4 w-4" />
+      </button>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,9 @@
+export type Event = {
+  id: string;
+  plant_id: string;
+  type: string;
+  note: string | null;
+  image_url: string | null;
+  public_id: string | null;
+  created_at: string;
+};

--- a/supabase/events.sql
+++ b/supabase/events.sql
@@ -8,6 +8,7 @@ create table if not exists public.events (
   type text not null,
   note text,
   image_url text,
+  public_id text,
   created_at timestamptz default now()
 );
 
@@ -23,4 +24,5 @@ create policy "public write events" on public.events
 
 -- Ensure column exists for existing installations
 alter table if exists public.events
-  add column if not exists image_url text;
+  add column if not exists image_url text,
+  add column if not exists public_id text;

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/components/AddNoteForm", () => ({ default: () => null }));
 vi.mock("@/components/AddPhotoForm", () => ({ default: () => null }));
 vi.mock("@/components/CareTimeline", () => ({ default: () => null }));
+vi.mock("@/components/DeletePhotoButton", () => ({ default: () => null }));
 vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => (
     <a href={href}>{children}</a>


### PR DESCRIPTION
## Summary
- store Cloudinary public IDs for event photos
- add DELETE `/api/events/:id` endpoint to remove events and images
- expose delete button for photo events

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c215ec7083248273926928881f38