### PR TITLE
Handle pot size units for AI care

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -150,8 +150,21 @@ export default function AddPlantForm() {
   const generateCarePlan = async () => {
     try {
       setLoadingCare(true);
-      const { latitude, longitude, species, potSize, lightLevel, humidity } =
-        getValues();
+      const {
+        latitude,
+        longitude,
+        species,
+        potSize,
+        potUnit,
+        lightLevel,
+        humidity,
+      } = getValues();
+      const potSizeCm =
+        typeof potSize === "number"
+          ? potUnit === "in"
+            ? potSize * 2.54
+            : potSize
+          : undefined;
       const res = await fetch("/api/ai-care", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -159,7 +172,8 @@ export default function AddPlantForm() {
           latitude: latitude ? parseFloat(latitude) : undefined,
           longitude: longitude ? parseFloat(longitude) : undefined,
           species: species || undefined,
-          potSize: typeof potSize === "number" ? potSize : undefined,
+          potSize: potSizeCm,
+          potUnit: potUnit || undefined,
           lightLevel: lightLevel || undefined,
           humidity: humidity ? parseFloat(humidity) : undefined,
         }),
@@ -211,7 +225,12 @@ export default function AddPlantForm() {
             longitude: data.longitude ? parseFloat(data.longitude) : undefined,
             species: data.species || undefined,
             potSize:
-              typeof data.potSize === "number" ? data.potSize : undefined,
+              typeof data.potSize === "number"
+                ? data.potUnit === "in"
+                  ? data.potSize * 2.54
+                  : data.potSize
+                : undefined,
+            potUnit: data.potUnit || undefined,
             lightLevel: data.lightLevel || undefined,
             humidity: data.humidity
               ? parseFloat(data.humidity)

--- a/tests/ai-care.api.test.ts
+++ b/tests/ai-care.api.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+
+describe("POST /api/ai-care", () => {
+  it("uses inches in rationale when potUnit is 'in'", async () => {
+    const { POST } = await import("../src/app/api/ai-care/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ potSize: 25.4, potUnit: "in" }),
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.rationale).toContain("10in");
+  });
+
+  it("uses centimeters in rationale when potUnit is 'cm'", async () => {
+    const { POST } = await import("../src/app/api/ai-care/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ potSize: 10, potUnit: "cm" }),
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.rationale).toContain("10cm");
+  });
+});


### PR DESCRIPTION
## Summary
- Convert inch pot sizes to centimeters and pass potUnit when generating care plans
- Allow ai-care route to accept potUnit and format prompts and rationales with the correct units
- Add API tests verifying rationale output for inch and centimeter pot sizes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c2297fd4832485f9854dd4881f41