### PR TITLE
Allow deleting plants from edit page

### DIFF
--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -38,3 +38,23 @@ export async function PATCH(
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    const { error } = await supabase
+      .from("plants")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", getCurrentUserId());
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("DELETE /plants/[id] error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/EditPlantForm.tsx
+++ b/src/components/EditPlantForm.tsx
@@ -156,6 +156,18 @@ export default function EditPlantForm({ plant }: EditPlantFormProps) {
     }
   };
 
+  const handleDelete = async () => {
+    if (!confirm("Delete this plant?")) return;
+    const res = await fetch(`/api/plants/${plant.id}`, { method: "DELETE" });
+    if (res.ok) {
+      toast("Plant deleted");
+      router.push("/plants");
+      router.refresh();
+    } else {
+      toast("Failed to delete plant");
+    }
+  };
+
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       <div className="space-y-4 rounded-xl border bg-card p-6 text-foreground shadow-sm">
@@ -380,7 +392,16 @@ export default function EditPlantForm({ plant }: EditPlantFormProps) {
         </div>
       </div>
 
-      <Button type="submit">Save Plant</Button>
+      <div className="flex gap-2">
+        <Button type="submit">Save Plant</Button>
+        <Button
+          type="button"
+          variant="destructive"
+          onClick={handleDelete}
+        >
+          Delete Plant
+        </Button>
+      </div>
     </form>
   );
 }

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
 
-vi.mock("../src/lib/auth", () => ({
+vi.mock("@/lib/auth", () => ({
   getCurrentUserId: () => "user-123",
 }));
 
@@ -12,6 +12,11 @@ vi.mock("@supabase/supabase-js", () => ({
     from: () => ({
       insert: () => ({
         select: () => Promise.resolve({ data: [{ id: "1" }], error: null }),
+      }),
+      delete: () => ({
+        eq: () => ({
+          eq: () => Promise.resolve({ error: null }),
+        }),
       }),
     }),
   }),
@@ -46,5 +51,14 @@ describe("POST /api/plants", () => {
     const req = new Request("http://localhost", { method: "POST", body: form });
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/plants/[id]", () => {
+  it("returns 200 when deleting a plant", async () => {
+    const { DELETE } = await import("../src/app/api/plants/[id]/route");
+    const req = new Request("http://localhost", { method: "DELETE" });
+    const res = await DELETE(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- add DELETE endpoint for removing plants
- let users delete plants from the edit form
- cover DELETE handler with tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c2a8b8588324925641cf0141a75d