### PR TITLE
feat: enhance care coach with feedback and confidence

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -58,6 +58,7 @@ export default function AddPlantForm() {
       humidity?: number;
     };
     climateZone?: string;
+    confidence?: "low" | "medium" | "high";
   }
   const [carePlan, setCarePlan] = useState<CarePlan | null>(null);
   const [loadingCare, setLoadingCare] = useState(false);
@@ -593,6 +594,12 @@ export default function AddPlantForm() {
                 </p>
               )}
               <p className="text-muted-foreground">{carePlan.rationale}</p>
+              {carePlan.confidence && (
+                <p>Confidence: {carePlan.confidence}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                AI-generated guidance. Verify with local experts for critical issues.
+              </p>
             </div>
           )}
         </div>
@@ -613,6 +620,11 @@ export default function AddPlantForm() {
             {carePlan && (
               <p>
                 <strong>Care Plan:</strong> water {carePlan.waterEvery} ({formatWaterAmount(carePlan.waterAmountMl)}), fertilize {carePlan.fertEvery}
+                {carePlan.confidence && (
+                  <>
+                    {" "}(confidence: {carePlan.confidence})
+                  </>
+                )}
               </p>
             )}
             {photoPreview && (

--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -52,6 +52,18 @@ export async function POST(req: Request) {
     rationale: string;
   } | null = null;
 
+  let confidence: "low" | "medium" | "high" = "low";
+
+  const infoProvided = [
+    species,
+    typeof potSize === "number" ? potSize : null,
+    lightLevel,
+    typeof weather.humidity === "number" ? weather.humidity : null,
+    climateZone,
+  ].filter((v) => v !== undefined && v !== null);
+  if (infoProvided.length >= 4) confidence = "high";
+  else if (infoProvided.length >= 2) confidence = "medium";
+
   if (process.env.OPENAI_API_KEY) {
     try {
       const potSizePrompt =
@@ -128,5 +140,6 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
     rationale,
     weather,
     climateZone,
+    confidence,
   });
 }

--- a/src/app/api/care-feedback/route.ts
+++ b/src/app/api/care-feedback/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "@/lib/auth";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+const schema = z.object({
+  plant_id: z.string().uuid(),
+  feedback: z.enum(["helpful", "not_helpful"]),
+});
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const { plant_id, feedback } = schema.parse(json);
+
+    const { error: plantCheckError } = await supabase
+      .from("plants")
+      .select("id")
+      .eq("id", plant_id)
+      .eq("user_id", getCurrentUserId())
+      .single();
+    if (plantCheckError) {
+      return NextResponse.json({ error: "Plant not found" }, { status: 404 });
+    }
+
+    const { error } = await supabase
+      .from("events")
+      .insert([{ plant_id, type: "feedback", note: feedback }]);
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("POST /care-feedback error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -4,6 +4,7 @@ import AddPhotoForm from "@/components/AddPhotoForm";
 import CareTimeline from "@/components/CareTimeline";
 import Link from "next/link";
 import DeletePhotoButton from "@/components/DeletePhotoButton";
+import CareSuggestion from "@/components/CareSuggestion";
 import {
   Tabs,
   TabsList,
@@ -39,6 +40,7 @@ type CarePlan = {
     humidity?: number;
   };
   climateZone?: string;
+  confidence?: "low" | "medium" | "high";
 };
 
 type Plant = {
@@ -206,16 +208,22 @@ export default async function PlantDetailPage({
                     )}
                   </li>
                 )}
+                {plant.care_plan.confidence && (
+                  <li>
+                    <span className="font-medium">Confidence:</span>{" "}
+                    {plant.care_plan.confidence}
+                  </li>
+                )}
+                <li className="text-xs text-muted-foreground">
+                  AI-generated care plan. Consult local experts for critical issues.
+                </li>
               </ul>
             ) : (
               <p className="text-sm text-muted-foreground">No care plan.</p>
             )}
           </section>
           {careSuggestion && (
-            <section className="rounded border-l-4 border-primary bg-accent p-4 text-sm text-primary">
-              <h2 className="mb-1 font-semibold">Care Coach</h2>
-              <p>{careSuggestion}</p>
-            </section>
+            <CareSuggestion plantId={plant.id} suggestion={careSuggestion} />
           )}
         </TabsContent>
 

--- a/src/components/CareSuggestion.tsx
+++ b/src/components/CareSuggestion.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui";
+import { toast } from "@/components/ui/sonner";
+
+interface Props {
+  plantId: string;
+  suggestion: string;
+}
+
+export default function CareSuggestion({ plantId, suggestion }: Props) {
+  const [submitted, setSubmitted] = useState(false);
+
+  const sendFeedback = async (feedback: "helpful" | "not_helpful") => {
+    try {
+      await fetch("/api/care-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plant_id: plantId, feedback }),
+      });
+      setSubmitted(true);
+      toast("Thanks for your feedback!");
+    } catch (err) {
+      console.error("Failed to send feedback:", err);
+    }
+  };
+
+  return (
+    <section className="rounded border-l-4 border-primary bg-accent p-4 text-sm text-primary">
+      <h2 className="mb-1 font-semibold">Care Coach</h2>
+      <p>{suggestion}</p>
+      <p className="mt-2 text-xs text-muted-foreground">
+        AI-generated suggestion. Consult local experts for persistent or unusual issues.
+      </p>
+      {!submitted ? (
+        <div className="mt-2 flex gap-2">
+          <Button size="sm" variant="secondary" onClick={() => sendFeedback("helpful")}>
+            Helpful
+          </Button>
+          <Button size="sm" variant="secondary" onClick={() => sendFeedback("not_helpful")}>
+            Not Helpful
+          </Button>
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">Thanks for your feedback!</p>
+      )}
+    </section>
+  );
+}

--- a/tests/ai-care.api.test.ts
+++ b/tests/ai-care.api.test.ts
@@ -22,4 +22,15 @@ describe("POST /api/ai-care", () => {
     const json = await res.json();
     expect(json.rationale).toContain("10cm");
   });
+
+  it("returns a confidence rating", async () => {
+    const { POST } = await import("../src/app/api/ai-care/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ species: "rose", potSize: 10, potUnit: "cm" }),
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.confidence).toBe("medium");
+  });
 });

--- a/tests/care-feedback.api.test.ts
+++ b/tests/care-feedback.api.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => "user-123",
+}));
+
+const insertMock = vi.fn().mockResolvedValue({ error: null });
+const selectMock = vi.fn().mockReturnValue({
+  eq: () => ({
+    eq: () => ({
+      single: () => Promise.resolve({ data: { id: "plant-1" }, error: null }),
+    }),
+  }),
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "plants") {
+        return { select: selectMock };
+      }
+      if (table === "events") {
+        return { insert: insertMock };
+      }
+      return {} as Record<string, never>;
+    },
+  }),
+}));
+
+describe("POST /api/care-feedback", () => {
+  it("records feedback", async () => {
+    const { POST } = await import("../src/app/api/care-feedback/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        plant_id: "4aa97bee-71f1-428e-843b-4c3c77493994",
+        feedback: "helpful",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(insertMock).toHaveBeenCalled();
+  });
+});

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/components/AddNoteForm", () => ({ default: () => null }));
 vi.mock("@/components/AddPhotoForm", () => ({ default: () => null }));
 vi.mock("@/components/CareTimeline", () => ({ default: () => null }));
 vi.mock("@/components/DeletePhotoButton", () => ({ default: () => null }));
+vi.mock("@/components/CareSuggestion", () => ({ default: () => null }));
 vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => (
     <a href={href}>{children}</a>


### PR DESCRIPTION
## Summary
- score AI care plans with a confidence rating
- display AI-care disclaimer and let users rate suggestions
- add API endpoint and tests for care suggestion feedback

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5777dd883249f105066acb1683e