### PR TITLE
docs: clarify species autosuggest provider

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [ ] **Identify**
   - [x] Plant nickname
-  - [x] Species autosuggest (Perenual API)
+  - [x] Species autosuggest (OpenAI API)
   - [x] Optional photo upload
 
 - [ ] **Place**


### PR DESCRIPTION
## Summary
- note that species autosuggest relies on OpenAI, replacing outdated Perenual reference

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74216358c83248f14c8fd0bc9d9c0