### PR TITLE
Show today's tasks on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flora is a personalized plant care companion built with Next.js and Supabase.
 - See quick stats for each plant's care plan, including watering schedule, water amount, and last/next watering dates.
 - Edit a plant's care plan from its detail page.
 - Get gentle Care Coach suggestions when a plant's watering is overdue.
-- Review overdue, today, and upcoming care tasks on `/today`.
+- Review overdue, today, and upcoming care tasks on the home page.
 - Swipe a task right to mark it done or left to snooze it on the Today page.
 - Snoozing tasks asks for an optional reason to help adjust care plans.
 - Receive push notifications for due tasks via Supabase Edge Functions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,6 +121,6 @@ Flora is a personalized plant care companion for one user — you. It aims to ma
 
 - [x] Wrap up Plant Detail timeline view
 - [x] Build Rooms + Plant List page
-- [x] Add `/app/today` for task view
+- [x] Add home page (`/`) for task view
 - [x] Evaluate Supabase Auth vs hardcoded single-user fallback
 - [x] Polish visual style, typography, and interactions

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "./today/loading";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,1 @@
+export { default, revalidate } from "./today/page";

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 const links = [
-  { href: '/today', label: 'Today' },
+  { href: '/', label: 'Today' },
   { href: '/plants', label: 'Plants' },
   { href: '/add', label: 'Add' },
 ];

--- a/style_guide.md
+++ b/style_guide.md
@@ -323,7 +323,7 @@ export const buttonVariants = cva(
 - **Rooms + List/Grid**: toolbar with room select + toggle; card/list patterns.
 - **Detail Page**: photo hero, quick-stat pills, timeline (filterable), notes & gallery.
 - **Care Coach**: accent card only when overdue; up to 2 suggestions + CTA.
-- **/today**: sectioned lists; swipe + button alternatives; snooze modal with optional reason.
+- **Home (/)**: sectioned lists; swipe + button alternatives; snooze modal with optional reason.
 - **Push Notifications**: tone and iconography align with toasts.
 - **Import/Export**: grouped actions, guardrails, confirmation.
 - **Theme Toggle**: navbar action; persists via `next-themes`.

--- a/tests/navigation.test.tsx
+++ b/tests/navigation.test.tsx
@@ -14,7 +14,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-let pathname = '/today';
+let pathname = '/';
 vi.mock('next/navigation', () => ({
   usePathname: () => pathname,
 }));
@@ -22,7 +22,7 @@ vi.mock('next/navigation', () => ({
 describe('Navigation', () => {
   it('renders links to all sections', () => {
     const html = renderToString(<Navigation />);
-    expect(html).toContain('href="/today"');
+    expect(html).toContain('href="/"');
     expect(html).toContain('href="/plants"');
     expect(html).toContain('href="/add"');
   });


### PR DESCRIPTION
## Summary
- Display today's task view at the root path and share its loading state
- Point the navigation's Today link to the new home page
- Refresh docs and tests for the updated route

## Testing
- `pnpm test`
- `curl -I http://localhost:3000` *(fails: 500 Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a72f01c654832497a87bedbb13e0ae