### PR TITLE
Preserve photo in add plant form so hero image is saved

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -107,13 +107,16 @@ export default function AddPlantForm() {
   const selectedPotMaterial = watch("potMaterial");
   const selectedSoilType = watch("soilType");
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [persistedPhoto, setPersistedPhoto] = useState<File | null>(null);
   useEffect(() => {
     if (photoFile && photoFile.length > 0) {
       const file = photoFile[0];
+      setPersistedPhoto(file);
       const url = URL.createObjectURL(file);
       setPhotoPreview(url);
       return () => URL.revokeObjectURL(url);
     }
+    setPersistedPhoto(null);
     setPhotoPreview(null);
   }, [photoFile]);
 
@@ -246,8 +249,8 @@ export default function AddPlantForm() {
         console.error("Failed to generate care plan:", err);
       }
     }
-    if (data.photo && data.photo.length > 0) {
-      formData.append("photo", data.photo[0]);
+    if (persistedPhoto) {
+      formData.append("photo", persistedPhoto);
     }
 
     const res = await fetch("/api/plants", {


### PR DESCRIPTION
## Summary
- Persist uploaded photo in multi-step add plant form
- Submit stored photo so new plants get a hero image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a74cc3e9388324a6f04855253635ac