### PR TITLE
feat: add analytics event logging

### DIFF
--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
 import { getCurrentUserId } from "../../../lib/auth";
+import { logEvent } from "../../../lib/analytics";
 import { z } from "zod";
 
 const supabase = createClient(
@@ -101,6 +102,8 @@ export async function POST(req: Request) {
       .select();
 
     if (error) throw error;
+
+    await logEvent("plant_created", { plant_id: data?.[0]?.id });
 
     return NextResponse.json({ data });
   } catch (err: unknown) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "@/lib/auth";
+import { logEvent } from "@/lib/analytics";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -22,6 +23,7 @@ export async function PATCH(
         .eq("id", id)
         .eq("user_id", getCurrentUserId());
       if (error) throw error;
+      await logEvent("task_completed", { task_id: id });
     } else if (action === "snooze") {
       let addDays = typeof days === "number" ? days : 1;
       if (reason === "Too busy") addDays = Math.max(addDays, 2);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,28 @@
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "./auth";
+
+export async function logEvent(
+  type: string,
+  payload: Record<string, unknown> = {},
+) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    console.warn("Supabase credentials not set; analytics event not logged");
+    return;
+  }
+
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+  const { error } = await supabase.from("analytics_events").insert({
+    user_id: getCurrentUserId(),
+    type,
+    payload,
+  });
+
+  if (error) {
+    console.error("Error logging analytics event:", error.message);
+  }
+}

--- a/supabase/analytics.sql
+++ b/supabase/analytics.sql
@@ -1,0 +1,21 @@
+-- Run this in Supabase SQL editor to set up analytics events table
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.analytics_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null,
+  type text not null,
+  payload jsonb,
+  created_at timestamptz default now()
+);
+
+alter table public.analytics_events enable row level security;
+
+drop policy if exists "user read analytics_events" on public.analytics_events;
+create policy "user read analytics_events" on public.analytics_events
+  for select using (auth.uid()::text = user_id);
+
+drop policy if exists "user insert analytics_events" on public.analytics_events;
+create policy "user insert analytics_events" on public.analytics_events
+  for insert with check (auth.uid()::text = user_id);


### PR DESCRIPTION
## Summary
- add Supabase `analytics_events` table with RLS
- expose `logEvent` helper for recording analytics events
- log plant creation and task completion events

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f33bed48324a47de15ded78a603