### PR TITLE
Validate plant image URLs before rendering

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -97,7 +97,18 @@ export default async function PlantDetailPage({
   const otherEvents =
     timeline?.filter((e) => e.type !== "note" && e.type !== "photo") || [];
 
-  const headerImageUrl = plant.image_url ?? photoEvents[0]?.image_url ?? null;
+  let headerImageUrl = plant.image_url ?? photoEvents[0]?.image_url ?? null;
+
+  if (headerImageUrl) {
+    try {
+      const res = await fetch(headerImageUrl, { method: "HEAD" });
+      if (!res.ok) {
+        headerImageUrl = null;
+      }
+    } catch {
+      headerImageUrl = null;
+    }
+  }
 
   const lastWaterEvent = otherEvents.find((e) => e.type === "water") || null;
   const lastWatered = lastWaterEvent


### PR DESCRIPTION
## Summary
- Avoid rendering broken plant header photos by checking if the `image_url` exists

## Testing
- `pnpm lint src/app/plants/[id]/page.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f098aa48324bba15feba5a1ef6f