### PR TITLE
Add stats page with analytics panel

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,11 @@
+import dynamic from "next/dynamic";
+
+const AnalyticsPanel = dynamic(() => import("@/components/analytics/AnalyticsPanel"), {
+  ssr: false,
+});
+
+export const revalidate = 60;
+
+export default function StatsPage() {
+  return <AnalyticsPanel />;
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'next/navigation';
 const links = [
   { href: '/', label: 'Today' },
   { href: '/plants', label: 'Plants' },
+  { href: '/stats', label: 'Stats' },
   { href: '/add', label: 'Add' },
 ];
 


### PR DESCRIPTION
## Summary
- add stats page that dynamically loads AnalyticsPanel and revalidates every minute
- expose stats link in navigation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a754e98d0c83249a6c24755f73dbc2