### PR TITLE
Add timeout handling to API fetches

### DIFF
--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,13 +1,28 @@
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeout = 10_000
+) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
 export async function POST(req: Request) {
-  const {
-    latitude,
-    longitude,
-    species,
-    potSize,
-    potUnit,
-    lightLevel,
-    humidity,
-  } = (await req.json().catch(() => ({}))) as {
+  try {
+    const {
+      latitude,
+      longitude,
+      species,
+      potSize,
+      potUnit,
+      lightLevel,
+      humidity,
+    } = (await req.json().catch(() => ({}))) as {
     latitude?: number;
     longitude?: number;
     species?: string;
@@ -17,28 +32,29 @@ export async function POST(req: Request) {
     humidity?: number;
   };
 
-  const weather: { temperature?: number; humidity?: number } = {};
-  let climateZone: string | undefined;
+    const weather: { temperature?: number; humidity?: number } = {};
+    let climateZone: string | undefined;
 
-  if (typeof latitude === "number" && typeof longitude === "number") {
-    try {
-      const weatherRes = await fetch(
-        `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,relativehumidity_2m`
-      );
-      const weatherData = await weatherRes.json();
-      weather.temperature = weatherData.current?.temperature_2m;
-      weather.humidity = weatherData.current?.relativehumidity_2m;
+    if (typeof latitude === "number" && typeof longitude === "number") {
+      try {
+        const weatherRes = await fetchWithTimeout(
+          `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,relativehumidity_2m`
+        );
+        const weatherData = await weatherRes.json();
+        weather.temperature = weatherData.current?.temperature_2m;
+        weather.humidity = weatherData.current?.relativehumidity_2m;
 
-      const climateRes = await fetch(
-        `https://climate-api.open-meteo.com/v1/climate?latitude=${latitude}&longitude=${longitude}&start_date=2020-01-01&end_date=2020-12-31&daily=usda_hardiness_zone`
-      );
-      const climateData = await climateRes.json();
-      const zone = climateData.daily?.usda_hardiness_zone?.[0];
-      if (zone !== undefined) climateZone = zone.toString();
-    } catch (err) {
-      console.error("Failed to fetch weather or climate zone:", err);
+        const climateRes = await fetchWithTimeout(
+          `https://climate-api.open-meteo.com/v1/climate?latitude=${latitude}&longitude=${longitude}&start_date=2020-01-01&end_date=2020-12-31&daily=usda_hardiness_zone`
+        );
+        const climateData = await climateRes.json();
+        const zone = climateData.daily?.usda_hardiness_zone?.[0];
+        if (zone !== undefined) climateZone = zone.toString();
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") throw err;
+        console.error("Failed to fetch weather or climate zone:", err);
+      }
     }
-  }
 
   if (typeof humidity === "number") {
     weather.humidity = humidity;
@@ -64,17 +80,17 @@ export async function POST(req: Request) {
   if (infoProvided.length >= 4) confidence = "high";
   else if (infoProvided.length >= 2) confidence = "medium";
 
-  if (process.env.OPENAI_API_KEY) {
-    try {
-      const potSizePrompt =
-        typeof potSize === "number"
-          ? potUnit === "in"
-            ? `${(potSize / 2.54).toFixed(1)}in`
-            : potUnit === "cm"
-            ? `${potSize}cm`
-            : `${potSize}`
-          : "unknown";
-      const prompt = `You are a helpful gardening assistant. Based on the following data, provide watering and fertilizing guidance in JSON format with keys waterEvery, waterAmountMl, fertEvery, fertFormula, and rationale. The rationale must mention the plant species. waterAmountMl must be a number representing the amount of water in milliliters needed each time the plant is watered.
+    if (process.env.OPENAI_API_KEY) {
+      try {
+        const potSizePrompt =
+          typeof potSize === "number"
+            ? potUnit === "in"
+              ? `${(potSize / 2.54).toFixed(1)}in`
+              : potUnit === "cm"
+              ? `${potSize}cm`
+              : `${potSize}`
+            : "unknown";
+        const prompt = `You are a helpful gardening assistant. Based on the following data, provide watering and fertilizing guidance in JSON format with keys waterEvery, waterAmountMl, fertEvery, fertFormula, and rationale. The rationale must mention the plant species. waterAmountMl must be a number representing the amount of water in milliliters needed each time the plant is watered.
 
 Species: ${species ?? "unknown"}
 Pot size: ${potSizePrompt}
@@ -83,27 +99,31 @@ Humidity: ${weather.humidity ?? "unknown"}%
 Climate zone: ${climateZone ?? "unknown"}
 Current temperature: ${weather.temperature ?? "unknown"}°C`;
 
-      const aiRes = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-mini",
-          messages: [{ role: "user", content: prompt }],
-          temperature: 0.7,
-        }),
-      });
-      const aiJson = await aiRes.json();
-      const text = aiJson.choices?.[0]?.message?.content;
-      if (text) {
-        aiData = JSON.parse(text);
+        const aiRes = await fetchWithTimeout(
+          "https://api.openai.com/v1/chat/completions",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            },
+            body: JSON.stringify({
+              model: "gpt-4o-mini",
+              messages: [{ role: "user", content: prompt }],
+              temperature: 0.7,
+            }),
+          }
+        );
+        const aiJson = await aiRes.json();
+        const text = aiJson.choices?.[0]?.message?.content;
+        if (text) {
+          aiData = JSON.parse(text);
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") throw err;
+        console.error("Failed to fetch AI recommendations:", err);
       }
-    } catch (err) {
-      console.error("Failed to fetch AI recommendations:", err);
     }
-  }
 
   if (!aiData) {
     aiData = {
@@ -132,14 +152,23 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
   if (climateZone) extra.push(`climate zone ${climateZone}`);
   const rationale = `${aiData.rationale} ${extra.join(", ")}.`.trim();
 
-  return Response.json({
-    waterEvery: aiData.waterEvery,
-    waterAmountMl: aiData.waterAmountMl,
-    fertEvery: aiData.fertEvery,
-    fertFormula: aiData.fertFormula,
-    rationale,
-    weather,
-    climateZone,
-    confidence,
-  });
+    return Response.json({
+      waterEvery: aiData.waterEvery,
+      waterAmountMl: aiData.waterAmountMl,
+      fertEvery: aiData.fertEvery,
+      fertFormula: aiData.fertFormula,
+      rationale,
+      weather,
+      climateZone,
+      confidence,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return Response.json(
+        { error: "Upstream request timed out" },
+        { status: 504 }
+      );
+    }
+    throw err;
+  }
 }

--- a/src/app/api/species/route.test.ts
+++ b/src/app/api/species/route.test.ts
@@ -68,7 +68,10 @@ describe("species API route", () => {
         image_url: null,
       },
     ]);
-    expect(fetchMock).toHaveBeenCalledWith(mockResponse[0].image_url, { method: "HEAD" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      mockResponse[0].image_url,
+      expect.objectContaining({ method: "HEAD" })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add reusable fetchWithTimeout helper with AbortController
- apply 10s timeout to all fetch calls in ai-care and species routes
- return 504 response when upstream requests time out

## Testing
- `pnpm lint src/app/api/ai-care/route.ts src/app/api/species/route.ts src/app/api/species/route.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a754daa7908324807d9bf5fc91930f