### PR TITLE
refactor: centralize supabase admin client

### DIFF
--- a/src/app/api/care-feedback/route.ts
+++ b/src/app/api/care-feedback/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 const schema = z.object({
   plant_id: z.string().uuid(),

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 import cloudinary from "@/lib/cloudinary";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 export async function DELETE(
   _req: Request,

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 import cloudinary from "@/lib/cloudinary";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 const allowedTypes = ["note", "photo"] as const;
 

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 import { toCsv } from "@/lib/csv";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
 
 export async function GET(req: Request) {
   try {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 export async function POST(req: Request) {
   try {

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 import { plantSchema } from "../route";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 export async function PATCH(
   req: Request,

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,15 +1,11 @@
 // src/app/api/plants/route.ts
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "../../../lib/auth";
 import { logEvent } from "../../../lib/analytics";
 import { z } from "zod";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!, // must be service role for inserts
-);
 
 export const plantSchema = z.object({
   name: z.string().min(1),

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
 
 export async function GET() {
   try {

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin as supabase } from "../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
 
 export const revalidate = 60;
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
+import { supabaseAdmin as supabase } from "../../../../lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 import { logEvent } from "@/lib/analytics";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
 
 const schema = z
   .object({

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,8 +1,14 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!  // server-only
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!; // server-only
 
-export const supabaseAdmin = createClient(url, serviceRole, {
-  auth: { persistSession: false },
-})
+declare global {
+  var supabaseAdmin: SupabaseClient | undefined;
+}
+
+export const supabaseAdmin =
+  globalThis.supabaseAdmin ??
+  (globalThis.supabaseAdmin = createClient(url, serviceRole, {
+    auth: { persistSession: false },
+  }));


### PR DESCRIPTION
## Summary
- export a singleton Supabase admin client
- replace per-route client creation with shared supabaseAdmin import

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7582369f08324b35b8f39204d5b17