### PR TITLE
Add API tests for tasks and species routes

### DIFF
--- a/tests/species.api.test.ts
+++ b/tests/species.api.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.OPENAI_API_KEY = "test-key";
+
+describe("GET /api/species", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns cached results for repeated queries", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo) => {
+      if (typeof input === "string" && input.includes("api.openai.com")) {
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "[]" } }] }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected fetch call: ${input}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { GET } = await import("../src/app/api/species/route");
+
+    const req = new Request("http://localhost/api/species?q=rose");
+    await GET(req);
+    await GET(req);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest entry when cache exceeds limit", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo) => {
+      if (typeof input === "string" && input.includes("api.openai.com")) {
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "[]" } }] }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected fetch call: ${input}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { GET } = await import("../src/app/api/species/route");
+
+    const firstReq = new Request("http://localhost/api/species?q=0");
+    await GET(firstReq);
+    await GET(firstReq);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    for (let i = 1; i <= 100; i++) {
+      const req = new Request(`http://localhost/api/species?q=${i}`);
+      await GET(req);
+    }
+
+    const reqAgain = new Request("http://localhost/api/species?q=0");
+    await GET(reqAgain);
+    expect(fetchMock).toHaveBeenCalledTimes(102);
+  });
+});
+
+export {};

--- a/tests/tasks.api.test.ts
+++ b/tests/tasks.api.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const logEvent = vi.fn();
+let taskUpdates: Record<string, unknown>[] = [];
+let plantCarePlan: Record<string, unknown> | null = null;
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => "user-123",
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  logEvent,
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "tasks") {
+        return {
+          update: (values: Record<string, unknown>) => {
+            taskUpdates.push(values);
+            return {
+              eq: () => ({
+                eq: () => Promise.resolve({ error: null }),
+              }),
+            };
+          },
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { due_date: "2024-01-01", plant_id: "plant-1" },
+                    error: null,
+                  }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "plants") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { care_plan: { waterEvery: "7 days" } },
+                    error: null,
+                  }),
+              }),
+            }),
+          }),
+          update: (values: Record<string, unknown>) => {
+            plantCarePlan = values.care_plan as Record<string, unknown>;
+            return {
+              eq: () => ({
+                eq: () => Promise.resolve({ error: null }),
+              }),
+            };
+          },
+        };
+      }
+      return {} as unknown as Record<string, never>;
+    },
+  }),
+}));
+
+describe("PATCH /api/tasks/[id]", () => {
+  beforeEach(() => {
+    taskUpdates = [];
+    plantCarePlan = null;
+    logEvent.mockReset();
+  });
+
+  it("marks a task as complete and logs the event", async () => {
+    const { PATCH } = await import("../src/app/api/tasks/[id]/route");
+    const req = new Request("http://localhost", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "complete" }),
+    });
+    const res = await PATCH(req, { params: { id: "1" } });
+    expect(res.status).toBe(200);
+    expect(taskUpdates[0]).toHaveProperty("completed_at");
+    expect(logEvent).toHaveBeenCalledWith("task_completed", { task_id: "1" });
+  });
+
+  it("snoozes a task and updates care plan when soil is wet", async () => {
+    const { PATCH } = await import("../src/app/api/tasks/[id]/route");
+    const req = new Request("http://localhost", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "snooze",
+        days: 1,
+        reason: "Soil still wet",
+      }),
+    });
+    const res = await PATCH(req, { params: { id: "1" } });
+    expect(res.status).toBe(200);
+    expect(taskUpdates[0]).toEqual({
+      due_date: "2024-01-02",
+      snooze_reason: "Soil still wet",
+    });
+    expect(plantCarePlan).toEqual({ waterEvery: "8 days" });
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add tasks.api.test.ts covering PATCH complete and snooze flows
- add species.api.test.ts mocking OpenAI and verifying cache behavior

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a758307f008324a69a5141d8d8ab9a