### PR TITLE
fix: remove unsupported dynamic ssr

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,5 @@
 import TodayPage, { revalidate } from "./today/page";
-import dynamic from "next/dynamic";
-
-const AnalyticsPanel = dynamic(
-  () => import("@/components/analytics/AnalyticsPanel"),
-  { ssr: false }
-);
+import AnalyticsPanel from "@/components/analytics/AnalyticsPanel";
 
 export { revalidate };
 

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,8 +1,4 @@
-import dynamic from "next/dynamic";
-
-const AnalyticsPanel = dynamic(() => import("@/components/analytics/AnalyticsPanel"), {
-  ssr: false,
-});
+import AnalyticsPanel from "@/components/analytics/AnalyticsPanel";
 
 export const revalidate = 60;
 


### PR DESCRIPTION
## Summary
- replace dynamic AnalyticsPanel import with direct import in home and stats pages

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c0476248324987f8975a1e2f725