### PR TITLE
refactor: centralize env configuration

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import env from "./src/lib/config";
 
 export function middleware(req: NextRequest) {
-  const expectedUser = process.env.BASIC_AUTH_USER;
-  const expectedPassword = process.env.BASIC_AUTH_PASSWORD;
+  const expectedUser = env.BASIC_AUTH_USER;
+  const expectedPassword = env.BASIC_AUTH_PASSWORD;
 
   // Skip auth if credentials are not set
   if (!expectedUser || !expectedPassword) {

--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,3 +1,5 @@
+import config from "../../../lib/config";
+
 async function fetchWithTimeout(
   url: string,
   options: RequestInit = {},
@@ -80,7 +82,7 @@ export async function POST(req: Request) {
   if (infoProvided.length >= 4) confidence = "high";
   else if (infoProvided.length >= 2) confidence = "medium";
 
-    if (process.env.OPENAI_API_KEY) {
+    if (config.OPENAI_API_KEY) {
       try {
         const potSizePrompt =
           typeof potSize === "number"
@@ -105,7 +107,7 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+              Authorization: `Bearer ${config.OPENAI_API_KEY}`,
             },
             body: JSON.stringify({
               model: "gpt-4o-mini",

--- a/src/app/api/species/route.ts
+++ b/src/app/api/species/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/species/route.ts
 import { NextResponse } from "next/server";
+import config from "../../../lib/config";
 
 async function fetchWithTimeout(
   url: string,
@@ -41,7 +42,7 @@ async function validateImageUrl(url: string): Promise<boolean> {
 }
 
 async function fetchOpenAISpecies(q: string): Promise<Species[]> {
-  const key = process.env.OPENAI_API_KEY;
+  const key = config.OPENAI_API_KEY;
   if (!key) throw new Error("Missing OPENAI_API_KEY");
   const res = await fetchWithTimeout(
     "https://api.openai.com/v1/chat/completions",
@@ -130,7 +131,7 @@ export async function GET(req: Request) {
   }
 
   try {
-    if (!process.env.OPENAI_API_KEY) {
+    if (!config.OPENAI_API_KEY) {
       console.warn(
         "Species search requested but no OPENAI_API_KEY configured"
       );

--- a/src/app/plants/[id]/edit/page.tsx
+++ b/src/app/plants/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import config from "../../../lib/config";
 import EditPlantForm from "@/components/EditPlantForm";
 import { getCurrentUserId } from "@/lib/auth";
 
@@ -12,8 +13,8 @@ export default async function EditPlantPage({
   const { id } = await params;
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    config.NEXT_PUBLIC_SUPABASE_URL,
+    config.SUPABASE_SERVICE_ROLE_KEY,
   );
 
   const { data: plant, error } = await supabase

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import config from "../../../lib/config";
 import AddNoteForm from "@/components/AddNoteForm";
 import AddPhotoForm from "@/components/AddPhotoForm";
 import CareTimeline from "@/components/CareTimeline";
@@ -66,8 +67,8 @@ export default async function PlantDetailPage({
   const { id } = await params;
 
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    config.NEXT_PUBLIC_SUPABASE_URL,
+    config.SUPABASE_SERVICE_ROLE_KEY,
   );
 
   const { data: plant, error: plantError } = await supabase

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,14 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "./auth";
+import config from "./config";
 
 export async function logEvent(
   type: string,
   payload: Record<string, unknown> = {},
 ) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = config.NEXT_PUBLIC_SUPABASE_URL;
   const key =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    config.SUPABASE_SERVICE_ROLE_KEY ?? config.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !key) {
     console.warn("Supabase credentials not set; analytics event not logged");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,9 +5,9 @@
  * Supabase Auth is added. The fallback must be a valid UUID so that queries
  * against columns typed as `uuid` do not error.
  */
-export const SINGLE_USER_ID =
-  process.env.NEXT_PUBLIC_SINGLE_USER_ID ??
-  "00000000-0000-0000-0000-000000000000";
+import config from "./config";
+
+export const SINGLE_USER_ID = config.SINGLE_USER_ID;
 
 export function getCurrentUserId() {
   return SINGLE_USER_ID;

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,9 +1,10 @@
 import { v2 as cloudinary } from "cloudinary";
+import config from "./config";
 
 cloudinary.config({
-  cloud_name: process.env.CLOUDINARY_CLOUD_NAME!,
-  api_key: process.env.CLOUDINARY_API_KEY!,
-  api_secret: process.env.CLOUDINARY_API_SECRET!,
+  cloud_name: config.CLOUDINARY_CLOUD_NAME,
+  api_key: config.CLOUDINARY_API_KEY,
+  api_secret: config.CLOUDINARY_API_SECRET,
   secure: true,
 });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,45 @@
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+}
+
+const config = {
+  get NEXT_PUBLIC_SUPABASE_URL() {
+    return required("NEXT_PUBLIC_SUPABASE_URL");
+  },
+  get NEXT_PUBLIC_SUPABASE_ANON_KEY() {
+    return required("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  },
+  get SUPABASE_SERVICE_ROLE_KEY() {
+    return required("SUPABASE_SERVICE_ROLE_KEY");
+  },
+  get CLOUDINARY_CLOUD_NAME() {
+    return required("CLOUDINARY_CLOUD_NAME");
+  },
+  get CLOUDINARY_API_KEY() {
+    return required("CLOUDINARY_API_KEY");
+  },
+  get CLOUDINARY_API_SECRET() {
+    return required("CLOUDINARY_API_SECRET");
+  },
+  get OPENAI_API_KEY() {
+    return process.env.OPENAI_API_KEY;
+  },
+  get BASIC_AUTH_USER() {
+    return process.env.BASIC_AUTH_USER;
+  },
+  get BASIC_AUTH_PASSWORD() {
+    return process.env.BASIC_AUTH_PASSWORD;
+  },
+  get SINGLE_USER_ID() {
+    return (
+      process.env.NEXT_PUBLIC_SINGLE_USER_ID ??
+      "00000000-0000-0000-0000-000000000000"
+    );
+  },
+};
+
+export default config;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from "@supabase/supabase-js";
+import config from "./config";
 
 export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  config.NEXT_PUBLIC_SUPABASE_URL,
+  config.NEXT_PUBLIC_SUPABASE_ANON_KEY,
 );

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,7 +1,8 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import config from "./config";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!; // server-only
+const url = config.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = config.SUPABASE_SERVICE_ROLE_KEY; // server-only
 
 declare global {
   var supabaseAdmin: SupabaseClient | undefined;


### PR DESCRIPTION
## Summary
- centralize environment variable handling in `src/lib/config`
- consume new config across middleware, supabase clients, cloudinary, and API routes
- remove direct `process.env` assertions from code

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75bb9842c8324bfe8d96a67c5687e