### PR TITLE
chore: align UI with style guide

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,7 @@
 
 :root {
   --font-inter: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --font-cabinet: Cabin, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
   --radius: 1rem;
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;
@@ -118,5 +119,13 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-inter);
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-cabinet);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Inter } from "next/font/google";
+import { Inter, Cabin } from "next/font/google";
 import type { ReactNode } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -7,10 +7,15 @@ import { Providers } from "./providers";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const cabinet = Cabin({ subsets: ["latin"], variable: "--font-cabinet" });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className={inter.variable}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${inter.variable} ${cabinet.variable}`}
+    >
       <body className="min-h-dvh antialiased">
         <Providers>
           <Toaster />

--- a/src/components/DeletePhotoButton.tsx
+++ b/src/components/DeletePhotoButton.tsx
@@ -33,7 +33,7 @@ export default function DeletePhotoButton({ eventId }: { eventId: string }) {
         type="button"
         onClick={handleDelete}
         disabled={loading}
-        className="rounded bg-black/60 p-1 text-white hover:bg-black/80 disabled:opacity-50"
+        className="rounded bg-black/60 p-2 text-white transition-colors duration-150 ease-out motion-reduce:transition-none hover:bg-black/80 disabled:opacity-50"
         aria-label="Delete photo"
       >
         <Trash2Icon className="h-4 w-4" />

--- a/src/components/EmptyStateCTA.tsx
+++ b/src/components/EmptyStateCTA.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui";
 
 export default function EmptyStateCTA() {
   return (
-    <div className="rounded border p-4 text-center">
-      <p className="mb-2">No tasks yet.</p>
+    <div className="rounded-xl border p-8 text-center bg-muted/30 shadow-sm">
+      <p className="mb-4">No tasks yet.</p>
       <Button asChild>
         <Link href="/add">Add your first plant</Link>
       </Button>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -24,7 +24,7 @@ export default function Navigation() {
               <Link
                 href={href}
                 aria-current={isActive ? "page" : undefined}
-                className={`rounded px-2 py-1 hover:bg-accent ${
+                className={`rounded px-4 py-2 transition-colors duration-200 ease-out motion-reduce:transition-none hover:bg-accent ${
                   isActive ? "bg-accent text-accent-foreground font-semibold" : ""
                 }`}
               >

--- a/src/components/PlantList.tsx
+++ b/src/components/PlantList.tsx
@@ -83,7 +83,7 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
                           {plant.name}
                         </div>
                       )}
-                      <CardContent className="p-2 text-center text-sm font-medium">
+                      <CardContent className="p-4 text-center text-sm font-medium">
                         {plant.name}
                       </CardContent>
                     </Card>

--- a/src/components/SnoozeDialog.tsx
+++ b/src/components/SnoozeDialog.tsx
@@ -38,7 +38,7 @@ export default function SnoozeDialog({
           <DialogTitle>Snooze Task</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label htmlFor="days">Days</Label>
             <Input
               id="days"
@@ -48,7 +48,7 @@ export default function SnoozeDialog({
               onChange={(e) => setDays(parseInt(e.target.value, 10) || 1)}
             />
           </div>
-          <div className="space-y-2">
+          <div className="space-y-3">
             <Label htmlFor="reason">Reason (optional)</Label>
             <Input
               id="reason"
@@ -56,7 +56,7 @@ export default function SnoozeDialog({
               onChange={(e) => setReason(e.target.value)}
             />
           </div>
-          <div className="flex justify-end gap-2">
+          <div className="flex justify-end gap-3">
             <Button
               type="button"
               variant="secondary"

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -29,7 +29,7 @@ export default function TaskItem({ task, today }: { task: Task; today: string })
       if (res.ok) {
         setIsCompleting(true);
         // allow animation to play before refreshing
-        setTimeout(() => router.refresh(), 300);
+        setTimeout(() => router.refresh(), 200);
       } else {
         toast("Failed to complete task");
       }
@@ -82,7 +82,7 @@ export default function TaskItem({ task, today }: { task: Task; today: string })
         onConfirm={handleSnooze}
       />
       <Card
-        className={`p-4 transition-all duration-300 ${isCompleting ? "opacity-0 translate-x-full" : ""}`}
+        className={`p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${isCompleting ? "opacity-0 translate-x-full" : ""}`}
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
       >
@@ -91,7 +91,7 @@ export default function TaskItem({ task, today }: { task: Task; today: string })
         {task.due_date !== today && (
           <div className="text-xs text-muted-foreground">{task.due_date}</div>
         )}
-        <div className="mt-2 flex gap-2 text-sm">
+        <div className="mt-4 flex gap-3 text-sm">
           <Button onClick={handleComplete}>Done</Button>
           <Button variant="secondary" onClick={() => setSnoozeOpen(true)}>
             Snooze

--- a/src/components/analytics/AnalyticsPanel.tsx
+++ b/src/components/analytics/AnalyticsPanel.tsx
@@ -36,10 +36,10 @@ export default function AnalyticsPanel() {
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
-      <div className="rounded-lg border bg-card p-4">
+      <div className="rounded-xl border bg-card p-4 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0">
         <LineChart data={stats.daily} />
       </div>
-      <div className="rounded-lg border bg-card p-4">
+      <div className="rounded-xl border bg-card p-4 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0">
         <BarChart data={stats.weekly} />
       </div>
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors duration-200 ease-out motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none",
   {
     variants: {
       variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- include Cabin font for headings alongside Inter
- use Cabin font for all heading tags
- standardize analytics cards to rounded-xl per style guide
- enforce spacing and motion tokens across components

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75eb7edb48324b4e6b658efec0a87