### PR TITLE
feat: switch to space grotesk font

### DIFF
--- a/flora-ui-style-guide.md
+++ b/flora-ui-style-guide.md
@@ -19,15 +19,18 @@ Foundations for colors, typography, spacing, motion.
 ---
 
 ## 1.2 Typography
-- **Headlines** → `Cabinet Grotesk` (600–700 weight)  
+- **Headlines** → `Space Grotesk` (600–700 weight)
 - **Body/UI** → `Inter` (400–500 weight)
 
 Sizes: `xs, sm, base, lg, xl, 2xl` (≤ 3 per view).
 
 ```tsx
-import { Inter, Cabin } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-const cabinet = Cabin({ subsets: ["latin"], variable: "--font-cabinet" });
+const cabinet = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-cabinet",
+});
 // <html className={`${inter.variable} ${cabinet.variable}`}>
 ```
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
 
 :root {
   --font-inter: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
-  --font-cabinet: Cabin, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --font-cabinet: "Space Grotesk", system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
   --radius: 1rem;
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Inter, Cabin } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 import type { ReactNode } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -7,7 +7,10 @@ import { Providers } from "./providers";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-const cabinet = Cabin({ subsets: ["latin"], variable: "--font-cabinet" });
+const cabinet = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-cabinet",
+});
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- replace Cabin with Space Grotesk for heading font
- update global font CSS variable and documentation
- ensure headings use `var(--font-cabinet)` in both themes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Could not resolve ../../../lib/config and failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7657956b88324be080fd16c209d6e