### PR TITLE
Use Inter font for all text

### DIFF
--- a/flora-ui-style-guide.md
+++ b/flora-ui-style-guide.md
@@ -19,19 +19,14 @@ Foundations for colors, typography, spacing, motion.
 ---
 
 ## 1.2 Typography
-- **Headlines** → `Space Grotesk` (600–700 weight)
-- **Body/UI** → `Inter` (400–500 weight)
+- **All text** → `Inter` (400–700 weight)
 
 Sizes: `xs, sm, base, lg, xl, 2xl` (≤ 3 per view).
 
 ```tsx
-import { Inter, Space_Grotesk } from "next/font/google";
+import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-const cabinet = Space_Grotesk({
-  subsets: ["latin"],
-  variable: "--font-cabinet",
-});
-// <html className={`${inter.variable} ${cabinet.variable}`}>
+// <html className={inter.variable}>
 ```
 
 ---

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,6 @@
 
 :root {
   --font-inter: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
-  --font-cabinet: "Space Grotesk", system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
   --radius: 1rem;
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;
@@ -119,13 +118,5 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-inter);
-  }
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-family: var(--font-cabinet);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Inter, Space_Grotesk } from "next/font/google";
+import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -7,17 +7,13 @@ import { Providers } from "./providers";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-const cabinet = Space_Grotesk({
-  subsets: ["latin"],
-  variable: "--font-cabinet",
-});
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${inter.variable} ${cabinet.variable}`}
+      className={inter.variable}
     >
       <body className="min-h-dvh antialiased">
         <Providers>


### PR DESCRIPTION
## Summary
- remove Space Grotesk and only load Inter from Google Fonts
- use Inter in global styles and documentation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7687c9c6c8324b88c8a2a68e88f65