### PR TITLE
refactor: wrap analytics charts in card components

### DIFF
--- a/src/components/analytics/AnalyticsPanel.tsx
+++ b/src/components/analytics/AnalyticsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+import { Card, CardContent } from "@/components/ui";
 
 const LineChart = dynamic(() => import("@/components/ui/line-chart").then(m => m.LineChart), {
   ssr: false,
@@ -36,12 +37,16 @@ export default function AnalyticsPanel() {
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
-      <div className="rounded-xl border bg-card p-4 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0">
-        <LineChart data={stats.daily} />
-      </div>
-      <div className="rounded-xl border bg-card p-4 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0">
-        <BarChart data={stats.weekly} />
-      </div>
+      <Card>
+        <CardContent>
+          <LineChart data={stats.daily} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <BarChart data={stats.weekly} />
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use `Card` and `CardContent` for analytics charts

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a769f7a09c8324b0a6693d8eaf7d19