### PR TITLE
feat: enhance task actions with icons and badges

### DIFF
--- a/src/components/SnoozeDialog.tsx
+++ b/src/components/SnoozeDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button, Input, Label } from "@/components/ui";
+import { Clock } from "lucide-react";
 
 interface SnoozeDialogProps {
   open: boolean;
@@ -64,7 +65,10 @@ export default function SnoozeDialog({
             >
               Cancel
             </Button>
-            <Button type="submit">Snooze</Button>
+            <Button type="submit">
+              <Clock className="mr-1 h-4 w-4" strokeWidth={1.5} />
+              Snooze
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Card } from "@/components/ui";
+import { Badge, Button, Card } from "@/components/ui";
 import { toast } from "@/components/ui/sonner";
+import { Check, Clock } from "lucide-react";
 import SnoozeDialog from "./SnoozeDialog";
 
 type PlantInfo = { id: string; name: string };
@@ -82,18 +83,26 @@ export default function TaskItem({ task, today }: { task: Task; today: string })
         onConfirm={handleSnooze}
       />
       <Card
-        className={`p-4 transition-all duration-200 ease-out motion-reduce:transition-none ${isCompleting ? "opacity-0 translate-x-full" : ""}`}
+        className={`p-4 transition-all duration-200 ease-out motion-reduce:transition-none hover:shadow-md hover:translate-y-[-1px] ${
+          isCompleting ? "opacity-0 translate-x-full shadow-md translate-y-[-1px]" : ""
+        }`}
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
       >
-        <div className="font-semibold">{task.type}</div>
+        <Badge variant="outline" className="mb-1">
+          {task.type}
+        </Badge>
         {plant && <div className="text-sm text-muted-foreground">{plant.name}</div>}
         {task.due_date !== today && (
           <div className="text-xs text-muted-foreground">{task.due_date}</div>
         )}
         <div className="mt-4 flex gap-3 text-sm">
-          <Button onClick={handleComplete}>Done</Button>
+          <Button onClick={handleComplete}>
+            <Check className="mr-1 h-4 w-4" strokeWidth={1.5} />
+            Done
+          </Button>
           <Button variant="secondary" onClick={() => setSnoozeOpen(true)}>
+            <Clock className="mr-1 h-4 w-4" strokeWidth={1.5} />
             Snooze
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- add lucide Check and Clock icons to Done/Snooze actions with uniform stroke widths
- style task pills with Badge components for quick stats
- improve task card motion with hover shadow and lift

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76a0b37988324ac7c2f74b74ddaa0