### PR TITLE
fix: remove duplicate lucide imports

### DIFF
--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -5,7 +5,6 @@ import { Badge, Button, Card } from "@/components/ui";
 import { toast } from "@/components/ui/sonner";
 import { Check, Clock } from "lucide-react";
 import SnoozeDialog from "./SnoozeDialog";
-import { Check, Clock } from "lucide-react";
 
 type PlantInfo = { id: string; name: string };
 export type Task = {


### PR DESCRIPTION
## Summary
- remove duplicate lucide-react icon imports from TaskItem

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76ba603288324a9d3d833ab4200f2