### PR TITLE
feat: wire up add plant form

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { toast } from "@/components/ui/sonner";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -58,8 +60,35 @@ export default function AddPlantPage() {
     },
     mode: "onBlur",
   });
-  const onSubmit = (values: FormValues) => {
-    console.log("Submit Add Plant:", values);
+  const router = useRouter();
+  const onSubmit = async (values: FormValues) => {
+    const formData = new FormData();
+    formData.append("name", values.nickname);
+    formData.append("species", values.species);
+    formData.append("room", values.room);
+    formData.append("pot_size", `${values.potSize} ${values.potUnit}`);
+    if (values.potMaterial) formData.append("pot_material", values.potMaterial);
+    formData.append("drainage", values.drainage);
+    if (values.soil) formData.append("soil_type", values.soil);
+    formData.append("light_level", values.light);
+    formData.append("indoor", values.location);
+
+    try {
+      const res = await fetch("/api/plants", { method: "POST", body: formData });
+      if (res.ok) {
+        const json = await res.json();
+        const id = json.data?.[0]?.id;
+        toast("Plant saved!");
+        if (id) {
+          router.push(`/plants/${id}`);
+          router.refresh();
+        }
+      } else {
+        toast("Failed to save plant");
+      }
+    } catch {
+      toast("Failed to save plant");
+    }
   };
 
   return (

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -34,7 +34,20 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
-vi.mock("@/components/ui", () => ({ Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button> }));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Badge: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+}));
 
 vi.mock("@supabase/supabase-js", () => ({
   createClient: () => ({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- connect add plant form to backend API
- configure vitest to resolve `@` alias and update mocks

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected HTML output to contain latest photo URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a7da3ce0048324b84431935f39446a