### PR TITLE
Remove duplicate submit button from confirm step

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -484,9 +484,6 @@ function Confirm({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
             <Summary label="Pot" value={`${values.potSize}${values.potUnit} ${values.potMaterial}`} />
           </div>
         </div>
-        <Button type="submit" className="rounded-xl bg-primary text-primary-foreground">
-          <CheckCircle2 className="h-4 w-4 mr-1" /> Save Plant
-        </Button>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- remove internal "Save Plant" button from Confirm step so submission is handled by footer button

## Testing
- `pnpm lint` (fails: Unexpected any errors in unrelated files)
- `pnpm test` (fails: Cannot find package '@/components/ui/button')

------
https://chatgpt.com/codex/tasks/task_e_68a7e71199b88324807986c3bb08bd46