### PR TITLE
Wire species autosuggest into add plant form

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -16,6 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
+import SpeciesAutosuggest from "@/components/SpeciesAutosuggest";
 
 // lucide-react icons
 import {
@@ -199,7 +200,7 @@ function Field({
 }
 
 function Identify({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
-  const { register, formState: { errors } } = form;
+  const { register, control, formState: { errors } } = form;
   return (
     <Card className="bg-card/95 border border-muted rounded-2xl shadow-sm">
       <CardHeader className="pb-2">
@@ -213,8 +214,18 @@ function Identify({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
         </Field>
 
         <Field label="Species" id="species" required hint="Start typing to search." error={errors.species?.message}>
-          {/* Swap with your real <SpeciesAutosuggest /> when ready */}
-          <Input id="species" {...register("species")} placeholder="Monstera deliciosa" aria-invalid={!!errors.species} className="h-11 rounded-xl" />
+          <Controller
+            control={control}
+            name="species"
+            render={({ field }) => (
+              <SpeciesAutosuggest
+                value={field.value}
+                onSelect={field.onChange}
+                onBlur={field.onBlur}
+                showLabel={false}
+              />
+            )}
+          />
         </Field>
 
         <div className="sm:col-span-2">

--- a/src/components/SpeciesAutosuggest.tsx
+++ b/src/components/SpeciesAutosuggest.tsx
@@ -13,9 +13,11 @@ type Species = {
 type Props = {
   value: string; // current text (from parent form)
   onSelect: (scientific: string, common?: string) => void; // callback
+  onBlur?: () => void; // notify parent of blur for validation
+  showLabel?: boolean; // allow hiding default label when wrapped externally
 };
 
-export default function SpeciesAutosuggest({ value, onSelect }: Props) {
+export default function SpeciesAutosuggest({ value, onSelect, onBlur, showLabel = true }: Props) {
   const [query, setQuery] = useState(value);
   const [results, setResults] = useState<Species[]>([]);
   const [loading, setLoading] = useState(false);
@@ -63,15 +65,20 @@ export default function SpeciesAutosuggest({ value, onSelect }: Props) {
 
   return (
     <div className="relative w-full">
-      <Label htmlFor="species" className="mb-1 block text-sm font-medium">
-        Species
-      </Label>
+      {showLabel && (
+        <Label htmlFor="species" className="mb-1 block text-sm font-medium">
+          Species
+        </Label>
+      )}
       <Input
         id="species"
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        onBlur={() => onSelect(query)}
+        onBlur={() => {
+          onSelect(query);
+          onBlur?.();
+        }}
         placeholder="Search for a plant..."
       />
 


### PR DESCRIPTION
## Summary
- integrate `SpeciesAutosuggest` into the Add Plant page
- allow the autosuggest component to hide its label and notify blur events

## Testing
- `pnpm lint src/app/add/page.tsx src/components/SpeciesAutosuggest.tsx`
- `pnpm lint` *(fails: Unexpected any in src/app/plants/page.tsx)*
- `pnpm test` *(fails: Cannot find package '@/components/ui/button')*

------
https://chatgpt.com/codex/tasks/task_e_68a7e7df63fc8324aa6c89628ea64985