### PR TITLE
refactor: improve contrast for accent elements

### DIFF
--- a/src/app/plants/[id]/detail-view.tsx
+++ b/src/app/plants/[id]/detail-view.tsx
@@ -120,7 +120,7 @@ export default function DetailView({ plant }: { plant: Plant }) {
 
       {/* Care Coach (overdue only) */}
       {overdue && (
-        <Card className="bg-accent/40 border border-accent rounded-2xl shadow-sm">
+        <Card className="bg-primary/10 border border-primary/40 rounded-2xl shadow-sm">
           <CardHeader className="pb-2">
             <CardTitle className="text-lg font-semibold flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-primary" /> Care Coach
@@ -221,7 +221,7 @@ export default function DetailView({ plant }: { plant: Plant }) {
 /* ---------------- UI Pieces ---------------- */
 function Stat({ label, value, icon }: { label: string; value: React.ReactNode; icon: React.ReactNode }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border bg-accent/40 px-3 py-1 text-xs">
+    <span className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs">
       {icon} <span className="font-medium">{label}:</span> {value}
     </span>
   );

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -114,7 +114,7 @@ function StatCard({
   return (
     <Card className="rounded-2xl border bg-white shadow-card">
       <CardContent className="p-6 flex items-center gap-4">
-        <div className="h-10 w-10 flex items-center justify-center rounded-full border bg-accent/40">
+        <div className="h-10 w-10 flex items-center justify-center rounded-full border border-primary/40 bg-primary/10">
           {icon}
         </div>
         <div>


### PR DESCRIPTION
## Summary
- replace low-contrast accent backgrounds with higher-contrast primary tones
- ensure plant detail stat chips and alerts use primary-tinted surfaces
- update stats icons container to use primary-tinted surface

## Testing
- `pnpm lint`
- `pnpm test`
- `node -e "function hslToRgb(h,s,l){s/=100;l/=100;let c=(1-Math.abs(2*l-1))*s;let x=c*(1-Math.abs((h/60)%2-1));let m=l-c/2;let [r1,g1,b1]=h<60?[c,x,0]:h<120?[x,c,0]:h<180?[0,c,x]:h<240?[0,x,c]:h<300?[x,0,c]:[c,0,x];let r=Math.round((r1+m)*255);let g=Math.round((g1+m)*255);let b=Math.round((b1+m)*255);return [r,g,b];}function blend(fg,alpha,bg){return fg.map((c,i)=>Math.round(alpha*c+(1-alpha)*bg[i]));}function relLum(rgb){let srgb=rgb.map(c=>{c/=255;return c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4);});return 0.2126*srgb[0]+0.7152*srgb[1]+0.0722*srgb[2];}function contrast(rgb1,rgb2){let L1=relLum(rgb1);let L2=relLum(rgb2);let brighter=Math.max(L1,L2),darker=Math.min(L1,L2);return (brighter+0.05)/(darker+0.05);}let primaryLight=hslToRgb(160,22,44);let backgroundLight=[255,255,255];let bgPrimary10Light=blend(primaryLight,0.1,backgroundLight);let textPrimary=primaryLight;let contrastIconLight=contrast(textPrimary,bgPrimary10Light);let foreground=hslToRgb(222.2,47.4,11.2);let contrastTextLight=contrast(foreground,bgPrimary10Light);let primaryDark=hslToRgb(160,22,52);let backgroundDark=hslToRgb(222.2,84,4.9);let bgPrimary10Dark=blend(primaryDark,0.1,backgroundDark);let textPrimaryDark=primaryDark;let foregroundDark=hslToRgb(210,40,98);let contrastIconDark=contrast(textPrimaryDark,bgPrimary10Dark);let contrastTextDark=contrast(foregroundDark,bgPrimary10Dark);console.log('Light icon contrast',contrastIconLight);console.log('Light text contrast',contrastTextLight);console.log('Dark icon contrast',contrastIconDark);console.log('Dark text contrast',contrastTextDark);"`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5db8e588324a0b1538ab59f85ab