### PR TITLE
feat: update card styling

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm transition-all duration-200 ease-out hover:shadow-md hover:-translate-y-px motion-reduce:transition-none motion-reduce:hover:shadow-sm motion-reduce:hover:translate-y-0",
+        "flex flex-col gap-6 rounded-2xl border bg-white py-6 shadow-card transition-all duration-200 ease-out hover:-translate-y-px hover:shadow-md motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-card",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- update card default styling to rounded-2xl, white background, and custom card shadow
- keep hover transitions and allow className overrides

## Testing
- `pnpm lint src/components/ui/card.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5d4c80c8324b5ce8cb41c422eff