### PR TITLE
style: refine EmptyStateCTA appearance

### DIFF
--- a/src/components/EmptyStateCTA.tsx
+++ b/src/components/EmptyStateCTA.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui";
 
 export default function EmptyStateCTA() {
   return (
-    <div className="rounded-xl border p-8 text-center bg-muted/30 shadow-sm">
+    <div className="rounded-2xl border p-8 text-center bg-white shadow-card">
       <p className="mb-4">No tasks yet.</p>
       <Button asChild>
         <Link href="/add">Add your first plant</Link>


### PR DESCRIPTION
## Summary
- use white background and card shadow for EmptyStateCTA
- use more rounded corners for EmptyStateCTA

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5c7a4e883248ed244af196fd097