### PR TITLE
Use theme card backgrounds

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -218,7 +218,7 @@ function Field({
 function Identify({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   const { register, control, formState: { errors } } = form;
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <Flower2 className="h-5 w-5 text-primary" /> Identify
@@ -264,7 +264,7 @@ function Identify({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
 function Place({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   const { control } = form;
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <MapPin className="h-5 w-5 text-primary" /> Place
@@ -336,7 +336,7 @@ function Place({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
 function PotSetup({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   const { control, register } = form;
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <Box className="h-5 w-5 text-primary" /> Pot Setup
@@ -446,7 +446,7 @@ function PotSetup({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
 function Environment({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   const { control } = form;
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <ThermometerSun className="h-5 w-5 text-primary" /> Environment
@@ -518,7 +518,7 @@ function SmartPlan({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   };
 
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <Sparkles className="h-5 w-5 text-primary" /> Smart Plan
@@ -575,7 +575,7 @@ function Confirm({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
   } catch {}
 
   return (
-    <Card className="bg-white border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
+    <Card className="border rounded-2xl shadow-card animate-in fade-in-50 slide-in-from-bottom-4">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold flex items-center gap-2">
           <Leaf className="h-5 w-5 text-primary" /> Confirm

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -128,7 +128,7 @@ export default function PlantsPage() {
               <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {items.map((p) => (
                   <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                    <Card className="bg-white rounded-2xl shadow-card transition transform hover:scale-[1.02]">
+                    <Card className="rounded-2xl shadow-card transition transform hover:scale-[1.02]">
                       <CardContent className="p-4">
                         <div className="aspect-video rounded-lg border bg-muted/50 mb-3 flex items-center justify-center">
                           <Leaf className="h-6 w-6 text-muted-foreground" />
@@ -149,7 +149,7 @@ export default function PlantsPage() {
               <div className="space-y-2">
                 {items.map((p) => (
                   <Link key={p.id} href={`/plants/${p.id}`} className="block">
-                    <Card className="bg-white rounded-2xl shadow-card transition transform hover:scale-[1.02]">
+                    <Card className="rounded-2xl shadow-card transition transform hover:scale-[1.02]">
                       <CardContent className="p-4 flex items-center gap-4">
                         <div className="h-12 w-16 rounded-md border bg-muted/50 flex items-center justify-center">
                           <Leaf className="h-5 w-5 text-muted-foreground" />

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -66,7 +66,7 @@ export default function StatsPage() {
 
       {/* Charts */}
       <div className="grid gap-6 lg:grid-cols-2">
-        <Card className="rounded-2xl border bg-white shadow-card">
+        <Card className="rounded-2xl border shadow-card">
           <CardHeader>
             <CardTitle>Watering Frequency</CardTitle>
           </CardHeader>
@@ -82,7 +82,7 @@ export default function StatsPage() {
           </CardContent>
         </Card>
 
-        <Card className="rounded-2xl border bg-white shadow-card">
+        <Card className="rounded-2xl border shadow-card">
           <CardHeader>
             <CardTitle>Weekly Tasks</CardTitle>
           </CardHeader>
@@ -112,7 +112,7 @@ function StatCard({
   value: string;
 }) {
   return (
-    <Card className="rounded-2xl border bg-white shadow-card">
+    <Card className="rounded-2xl border shadow-card">
       <CardContent className="p-6 flex items-center gap-4">
         <div className="h-10 w-10 flex items-center justify-center rounded-full border bg-accent/40">
           {icon}

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -45,7 +45,7 @@ export default function TodayPage() {
         {(["overdue", "today", "upcoming"] as const).map((key) => (
           <TabsContent value={key} key={key} className="space-y-2 pt-3">
             {DEMO.filter((t) => t.due === key).map((t) => (
-              <Card key={t.id} className="rounded-2xl bg-white shadow-card">
+              <Card key={t.id} className="rounded-2xl shadow-card">
                 <CardContent className="p-4 flex items-center gap-3">
                   {t.icon}
                   <div className="flex-1">{t.title}</div>


### PR DESCRIPTION
## Summary
- remove hard-coded white backgrounds so cards inherit theme styles
- ensure plant list, stats, today, and add pages all use default card colors

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f5a33660832487576f846af836c8