### PR TITLE
Enable photo uploads

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -52,6 +52,7 @@ const FormSchema = z.object({
   humidityOptIn: z.boolean().default(true),
   notes: z.string().optional(),
   carePlan: z.string(),
+  photo: z.any().optional(),
 });
 
 type FormValues = z.infer<typeof FormSchema>;
@@ -75,6 +76,7 @@ export default function AddPlantPage() {
       humidityOptIn: true,
       notes: "",
       carePlan: "",
+      photo: undefined,
     },
     mode: "onBlur",
   });
@@ -94,6 +96,7 @@ export default function AddPlantPage() {
       formData.set("drainage", values.drainage);
       if (values.soil) formData.set("soil_type", values.soil);
       formData.set("care_plan", values.carePlan);
+      if (values.photo instanceof File) formData.set("photo", values.photo);
 
       const res = await fetch("/api/plants", {
         method: "POST",
@@ -246,7 +249,13 @@ function Identify({ form }: { form: ReturnType<typeof useForm<FormValues>> }) {
 
         <Field label="Photo" id="photo">
           <div className="relative flex items-center justify-center h-32 rounded-xl border-2 border-dashed border-muted-foreground/25 bg-muted/30 transition hover:bg-muted/50">
-            <input type="file" accept="image/*" className="absolute inset-0 opacity-0 cursor-pointer" />
+            <input
+              type="file"
+              accept="image/*"
+              {...form.register("photo")}
+              onChange={(e) => form.setValue("photo", e.target.files?.[0])}
+              className="absolute inset-0 opacity-0 cursor-pointer"
+            />
             <ImageIcon className="h-6 w-6 text-muted-foreground" />
           </div>
         </Field>

--- a/src/app/plants/[id]/detail-view.tsx
+++ b/src/app/plants/[id]/detail-view.tsx
@@ -28,6 +28,8 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
+import AddPhotoForm from "@/components/AddPhotoForm";
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 export type Plant = {
   id: string;
@@ -35,6 +37,7 @@ export type Plant = {
   species: string;
   room?: string;
   photoUrl?: string;
+  photos: string[];
   nextWaterAt?: string | null;
   lastWaterAt?: string | null;
   waterEveryDays?: number | null;
@@ -51,7 +54,6 @@ export default function DetailView({ plant }: { plant: Plant }) {
     "Moved to brighter spot",
     "Repotted on **Aug 20**",
   ]);
-  const [photos] = React.useState<string[]>(["/placeholder.svg", "/placeholder.svg"]);
 
   return (
     <div className="mx-auto max-w-3xl px-5 sm:px-8 py-8 bg-background min-h-screen font-inter space-y-6">
@@ -91,9 +93,19 @@ export default function DetailView({ plant }: { plant: Plant }) {
             <Button className="rounded-xl" size="sm">
               <Plus className="h-4 w-4 mr-1" />Add Note
             </Button>
-            <Button className="rounded-xl" size="sm" variant="secondary">
-              <Camera className="h-4 w-4 mr-1" />Add Photo
-            </Button>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button className="rounded-xl" size="sm" variant="secondary">
+                  <Camera className="h-4 w-4 mr-1" />Add Photo
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Add Photo</DialogTitle>
+                </DialogHeader>
+                <AddPhotoForm plantId={plant.id} />
+              </DialogContent>
+            </Dialog>
           </div>
         </div>
       </header>
@@ -201,14 +213,24 @@ export default function DetailView({ plant }: { plant: Plant }) {
             {/* Gallery */}
             <TabsContent value="photos" className="space-y-3 pt-3">
               <div className="grid grid-cols-3 gap-2">
-                {photos.map((src, i) => (
+                {plant.photos.map((src, i) => (
                   <div key={i} className="relative aspect-square overflow-hidden rounded-xl border">
                     <Image src={src} alt="Photo" fill className="object-cover" />
                   </div>
                 ))}
-                <div className="aspect-square rounded-xl border-2 border-dashed flex items-center justify-center cursor-pointer hover:bg-muted/50 transition">
-                  <Plus className="h-6 w-6 text-muted-foreground" />
-                </div>
+                  <Dialog>
+                    <DialogTrigger asChild>
+                      <div className="aspect-square rounded-xl border-2 border-dashed flex items-center justify-center cursor-pointer hover:bg-muted/50 transition">
+                        <Plus className="h-6 w-6 text-muted-foreground" />
+                      </div>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Add Photo</DialogTitle>
+                      </DialogHeader>
+                      <AddPhotoForm plantId={plant.id} />
+                    </DialogContent>
+                  </Dialog>
               </div>
             </TabsContent>
           </Tabs>

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -22,14 +22,18 @@ export default async function PlantDetailPage({
     .eq("user_id", getCurrentUserId())
     .single();
 
+  const { data: eventsData } = await supabase
+    .from("events")
+    .select("image_url")
+    .eq("plant_id", id)
+    .eq("type", "photo")
+    .order("created_at", { ascending: false });
+
+  const photoUrls = eventsData?.map((e) => e.image_url).filter((u): u is string => !!u) ?? [];
+
   let photoUrl = plantData?.image_url as string | undefined;
   if (!photoUrl) {
-    const { data: eventsData } = await supabase
-      .from("events")
-      .select("image_url")
-      .eq("plant_id", id)
-      .order("created_at", { ascending: false });
-    photoUrl = eventsData?.[0]?.image_url ?? undefined;
+    photoUrl = photoUrls[0];
   }
 
   const plant: Plant = {
@@ -45,6 +49,7 @@ export default async function PlantDetailPage({
     light: (plantData?.light_level ?? undefined) as Plant["light"],
     pot: null,
     humidity: (plantData?.humidity as number | null) ?? null,
+    photos: photoUrls,
   };
 
   return <DetailView plant={plant} />;

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -93,19 +93,21 @@ vi.mock("@supabase/supabase-js", () => ({
         return {
           select: () => ({
             eq: () => ({
-              order: () =>
-                Promise.resolve({
-                  data: [
-                    {
-                      id: "evt1",
-                      type: "photo",
-                      note: null,
-                      image_url: "https://example.com/latest.jpg",
-                      created_at: "2023-01-01T00:00:00Z",
-                    },
-                  ],
-                  error: null,
-                }),
+              eq: () => ({
+                order: () =>
+                  Promise.resolve({
+                    data: [
+                      {
+                        id: "evt1",
+                        type: "photo",
+                        note: null,
+                        image_url: "https://example.com/latest.jpg",
+                        created_at: "2023-01-01T00:00:00Z",
+                      },
+                    ],
+                    error: null,
+                  }),
+              }),
             }),
           }),
         };


### PR DESCRIPTION
## Summary
- Support optional photo on Add Plant form and send file to API
- Show plant photos and Add Photo form on plant detail page
- Test updates for new photo event query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f80568548324968b2ce5a99cbdaa