### PR TITLE
Improve switch off-state contrast

### DIFF
--- a/src/app-old/globals.css
+++ b/src/app-old/globals.css
@@ -53,7 +53,7 @@
   --primary-foreground: 0 0% 98%;
   --secondary: 160 32% 92%;
   --secondary-foreground: 160 22% 20%;
-  --muted: 210 40% 96.1%;
+  --muted: 210 40% 92%;
   --muted-foreground: 215.4 16.3% 46.9%;
   --accent: 160 32% 92%;
   --accent-foreground: 160 22% 20%;
@@ -88,7 +88,7 @@
   --primary-foreground: 222.2 84% 5%;
   --secondary: 160 22% 16%;
   --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 10%;
+  --muted: 217.2 32.6% 20%;
   --muted-foreground: 215 20.2% 65.1%;
   --accent: 160 22% 16%;
   --accent-foreground: 210 40% 98%;

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-muted/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-border shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- increase Switch off-state contrast and add border
- darken `--muted` colors for light and dark themes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a80773509c832492fe9e42a86a1a2b