### PR TITLE
Fix config import and env references

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { baseUrl, appName, isDev } from "./src/lib/config";
+import { baseUrl, appName, isDev } from "@/lib/config";
 
 
 export function middleware(req: NextRequest) {
-  const expectedUser = env.BASIC_AUTH_USER;
-  const expectedPassword = env.BASIC_AUTH_PASSWORD;
+  const expectedUser = process.env.BASIC_AUTH_USER;
+  const expectedPassword = process.env.BASIC_AUTH_PASSWORD;
 
   // Skip auth if credentials are not set
   if (!expectedUser || !expectedPassword) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,4 @@
-// Flora main app page placeholder
+export default function HomePage() {
+  return <div>Hello from Flora 🌿</div>;
+}
+


### PR DESCRIPTION
## Summary
- fix config import path in middleware
- use `process.env` for basic auth variables
- add HomePage component for default route

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa3ed08fd083249f22342cc7c4ecaf