### PR TITLE
fix: add analytics opt-out data attribute to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from "react";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    // Ensure attribute matches server-rendered HTML to avoid hydration warnings
+    <html lang="en" data-google-analytics-opt-out="">
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary
- ensure the `<html>` tag includes the `data-google-analytics-opt-out` attribute to match server-rendered markup and prevent hydration mismatch errors

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68aa414ede848324bd4798082aef786e