### PR TITLE
feat: add auth, analytics and supabase admin helpers

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+/**
+ * Stub analytics logger used by server routes.
+ *
+ * In the production application this would forward events to an analytics
+ * pipeline. For the test environment we simply provide an asynchronous
+ * placeholder so that calls can be awaited and easily mocked.
+ */
+export async function logEvent(
+  _event: string,
+  _data: Record<string, unknown> = {},
+): Promise<void> {
+  // Intentionally left blank.
+}
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,17 @@
+import { headers } from "next/headers";
+
+/**
+ * Returns the identifier of the currently authenticated user.
+ *
+ * The ID is extracted from the `x-user-id` header which is expected to be
+ * populated by upstream authentication middleware. An error is thrown when the
+ * header is missing to signal unauthenticated access.
+ */
+export function getCurrentUserId(): string {
+  const userId = headers().get("x-user-id");
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
+  return userId;
+}
+

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Server-side Supabase client authenticated with the service role key.
+ *
+ * This client has elevated privileges and should only be used in secure
+ * server-side environments such as API routes. Environment variables are
+ * expected to be configured with the Supabase project URL and service role key.
+ */
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+


### PR DESCRIPTION
## Summary
- implement `getCurrentUserId` helper reading user id from `x-user-id` header
- add stub `logEvent` for analytics
- create service-role supabase client `supabaseAdmin`

## Testing
- `pnpm test src/app-old/api/plants/route.test.ts`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2035f25c832486d5568c9cebec56