### PR TITLE
feat: add centralized config module

### DIFF
--- a/src/app-old/api/ai-care/route.ts
+++ b/src/app-old/api/ai-care/route.ts
@@ -1,4 +1,4 @@
-import config from "../../../lib/config";
+import { OPENAI_API_KEY } from "../../../lib/config";
 
 async function fetchWithTimeout(
   url: string,
@@ -82,7 +82,7 @@ export async function POST(req: Request) {
   if (infoProvided.length >= 4) confidence = "high";
   else if (infoProvided.length >= 2) confidence = "medium";
 
-    if (config.OPENAI_API_KEY) {
+    if (OPENAI_API_KEY) {
       try {
         const potSizePrompt =
           typeof potSize === "number"
@@ -107,7 +107,7 @@ Current temperature: ${weather.temperature ?? "unknown"}°C`;
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${config.OPENAI_API_KEY}`,
+                Authorization: `Bearer ${OPENAI_API_KEY}`,
             },
             body: JSON.stringify({
               model: "gpt-4o-mini",

--- a/src/app-old/api/species/route.ts
+++ b/src/app-old/api/species/route.ts
@@ -1,6 +1,6 @@
 // src/app/api/species/route.ts
 import { NextResponse } from "next/server";
-import config from "../../../lib/config";
+import { OPENAI_API_KEY } from "../../../lib/config";
 
 async function fetchWithTimeout(
   url: string,
@@ -42,7 +42,7 @@ async function validateImageUrl(url: string): Promise<boolean> {
 }
 
 async function fetchOpenAISpecies(q: string): Promise<Species[]> {
-  const key = config.OPENAI_API_KEY;
+  const key = OPENAI_API_KEY;
   if (!key) throw new Error("Missing OPENAI_API_KEY");
   const res = await fetchWithTimeout(
     "https://api.openai.com/v1/chat/completions",
@@ -131,12 +131,12 @@ export async function GET(req: Request) {
   }
 
   try {
-    if (!config.OPENAI_API_KEY) {
-      console.warn(
-        "Species search requested but no OPENAI_API_KEY configured"
-      );
-      return NextResponse.json({ data: [] });
-    }
+      if (!OPENAI_API_KEY) {
+        console.warn(
+          "Species search requested but no OPENAI_API_KEY configured"
+        );
+        return NextResponse.json({ data: [] });
+      }
 
     const results = await fetchOpenAISpecies(q);
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,16 @@
+const required = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+};
+
+export const baseUrl = required("NEXT_PUBLIC_BASE_URL");
+export const appName = required("NEXT_PUBLIC_APP_NAME");
+export const isDev = process.env.NODE_ENV !== "production";
+
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+const config = { baseUrl, appName, isDev, OPENAI_API_KEY };
+export default config;


### PR DESCRIPTION
## Summary
- add src/lib/config to centralize environment variable handling
- update legacy API routes to read OpenAI key from config

## Testing
- `NEXT_PUBLIC_BASE_URL=http://localhost NEXT_PUBLIC_APP_NAME=Flora pnpm lint`
- `NEXT_PUBLIC_BASE_URL=http://localhost NEXT_PUBLIC_APP_NAME=Flora pnpm test` *(fails: Cannot find module '../src/app/api/ai-care/route' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab202e77408324a4378a0fef755c01