### PR TITLE
feat: add species search API via OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flora creates personalized care plans and adapts them to your environment.
 ## 🚀 Features
 
 - 🌱 **Add a Plant**
-  - Smart species autosuggest (via Perenual API)
+  - Smart species autosuggest (via OpenAI API)
   - Auto-generated AI care plan
   - Room assignment & environment tagging
 
@@ -39,7 +39,7 @@ Flora creates personalized care plans and adapts them to your environment.
 - **Framework**: Next.js 15 w/ App Router, Server Components, Turbopack
 - **UI**: Tailwind CSS, shadcn/ui, Cabinet Grotesk + Inter fonts
 - **Database**: Supabase (Postgres + Auth + Storage)
-- **AI**: OpenAI (for care plan generation)
+- **AI**: OpenAI (for species suggestions & care plan generation)
 - **Weather**: Forecast API (local humidity, ET₀ support)
 - **Hosting**: Vercel
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 - [x] Project Init: Next.js App Router, Tailwind, shadcn/ui
 - [x] Data Layer: Supabase project, `.env` integration
 - [x] ORM: Prisma set up with Plant, Room, CareEvent, Photo, Note models
-- [x] AI / APIs: Connected OpenAI and Perenual APIs
+- [x] AI / APIs: Connected OpenAI API for species suggestions
 - [x] Style Guide: Color palette, fonts, layout principles documented in `/docs`
 - [x] Docs: `/roadmap.md`, `/style-guide.md`, `/README.md` complete
 
@@ -20,7 +20,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 **Goal:** “From curious plant person to confident caretaker — in under a minute.”
 
 ### Completed
-- [x] Multi-step form with nickname, species autosuggest (Perenual), pot size, room assignment, photo (optional), drainage, soil, humidity, light, etc.
+- [x] Multi-step form with nickname, species autosuggest (OpenAI), pot size, room assignment, photo (optional), drainage, soil, humidity, light, etc.
 - [x] Smart AI care plan generation (mocked)
 - [x] Local form state management + strong types
 

--- a/src/app/api/species/route.ts
+++ b/src/app/api/species/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+
+const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+const OPENAI_MODEL = 'gpt-4o-mini';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q');
+
+  if (!query) {
+    return NextResponse.json([]);
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'OPENAI_API_KEY is not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const res = await fetch(OPENAI_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a botanical assistant that returns plant species names as a JSON array.',
+          },
+          {
+            role: 'user',
+            content: `List up to 10 plant species names that match "${query}". Return a JSON array of strings.`,
+          },
+        ],
+        temperature: 0.2,
+      }),
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch species' },
+        { status: res.status }
+      );
+    }
+
+    type OpenAIResponse = {
+      choices?: {
+        message?: {
+          content?: string;
+        };
+      }[];
+    };
+
+    const data = (await res.json()) as OpenAIResponse;
+    const content = data.choices?.[0]?.message?.content ?? '[]';
+    let names: string[] = [];
+    try {
+      names = JSON.parse(content);
+    } catch {
+      // fallback if model returns non-JSON
+      names = content
+        .split(/[,\n]/)
+        .map((s) => s.replace(/^[\s"'-]+|[\s"'-]+$/g, ''))
+        .filter(Boolean)
+        .slice(0, 10);
+    }
+
+    return NextResponse.json(names);
+  } catch (err) {
+    console.error('Species search failed', err);
+    return NextResponse.json(
+      { error: 'Species search failed' },
+      { status: 500 }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/species` route that uses OpenAI to suggest plant species
- remove Perenual environment config and references
- document OpenAI-based species suggestions in README and roadmap

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find modules like '../src/lib/csv' and '../src/app/api/ai-care/route' in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68ab266d1b2483248c4d47e4873e9b97