### PR TITLE
docs: map color tokens to tailwind

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -12,3 +12,24 @@ This document defines the visual and UX standards for the Flora app.
 | Foreground    | #111827   | Main text                  |
 | Muted         | #9CA3AF   | Descriptive text, labels   |
 
+### Tailwind & shadcn mapping
+
+| Token     | Tailwind classes                     | shadcn CSS variables                     |
+|-----------|--------------------------------------|------------------------------------------|
+| Primary   | `bg-primary`, `text-primary-foreground`         | `--primary`, `--primary-foreground`     |
+| Secondary | `bg-secondary`, `text-secondary-foreground`     | `--secondary`, `--secondary-foreground` |
+| Background| `bg-background`, `text-foreground`               | `--background`, `--foreground`          |
+| Foreground| `text-foreground`                                | `--foreground`                          |
+| Muted     | `bg-muted`, `text-muted-foreground`              | `--muted`, `--muted-foreground`        |
+
+```tsx
+// components/Example.tsx
+export function Example() {
+  return (
+    <div className="bg-primary text-primary-foreground p-4 rounded-lg">
+      <p className="text-muted-foreground">Water me today!</p>
+    </div>
+  );
+}
+```
+


### PR DESCRIPTION
## Summary
- document color token mappings to Tailwind utilities and shadcn variables
- show example component using color tokens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68ab28cc2af08324b276e640e3bdd8d2