### PR TITLE
feat: add Supabase plant API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Smart species autosuggest (via OpenAI API)
   - Auto-generated AI care plan
   - Room assignment & environment tagging
+  - Persists new plants to Supabase via API
 
 - 📅 **Care Dashboard**
   - Today, Overdue, and Upcoming tasks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 - [x] Local form state management + strong types
 
 ### To Finish
-- [ ] Submit form → create plant in Supabase
+ - [x] Submit form → create plant in Supabase
 - [ ] Redirect to `/plants/[id]`
 - [ ] Fallback when no species selected
 - [ ] Light UI polish: spacing, transitions, preview step

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,0 +1,18 @@
+import { getCurrentUserId } from "@/lib/auth";
+import { supabaseAdmin } from "../../../../lib/supabaseAdmin";
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const userId = getCurrentUserId();
+  const { error } = await supabaseAdmin
+    .from("plants")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", userId);
+
+  if (error) {
+    return new Response("Database error", { status: 500 });
+  }
+
+  return new Response(null, { status: 200 });
+}

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,0 +1,38 @@
+import { getCurrentUserId } from "@/lib/auth";
+import { supabaseAdmin } from "../../../lib/supabaseAdmin";
+import { z } from "zod";
+
+const plantSchema = z.object({
+  name: z.string().min(1),
+  species: z.string().min(1),
+  potSize: z.string().optional(),
+  potMaterial: z.string().optional(),
+  lightLevel: z.string().optional(),
+  indoor: z.enum(["Indoor", "Outdoor"]).optional(),
+  drainage: z.string().optional(),
+  soilType: z.string().optional(),
+  humidity: z.string().optional(),
+  latitude: z.coerce.number().optional(),
+  longitude: z.coerce.number().optional(),
+});
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const data = Object.fromEntries(formData.entries());
+  const parsed = plantSchema.safeParse(data);
+  if (!parsed.success) {
+    return new Response("Invalid data", { status: 400 });
+  }
+
+  const userId = getCurrentUserId();
+  const { error, data: inserted } = await supabaseAdmin
+    .from("plants")
+    .insert({ ...parsed.data, user_id: userId })
+    .select();
+
+  if (error) {
+    return new Response("Database error", { status: 500 });
+  }
+
+  return new Response(JSON.stringify(inserted), { status: 200 });
+}


### PR DESCRIPTION
## Summary
- add POST /api/plants route to create plants in Supabase
- add DELETE /api/plants/[id] route
- document plant submission in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing modules)*
- `npx vitest run tests/plants.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab2922b6c88324a0b918fb1733c1cd