### PR TITLE
docs: link style guide for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See `/docs/deployment.md` for full production deployment steps.
 
 ## 🤝 Contributing
 
-See `/docs/contributing.md` to get started with local development and best practices.
+See [docs/contributing.md](./docs/contributing.md) for local development and best practices. For design standards, review the [style guide](./docs/style-guide.md).
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contributing to Flora
+
+Thanks for your interest in improving Flora! This guide covers the basics to get you started.
+
+## Development workflow
+
+1. Follow the setup instructions in the [README](../README.md).
+2. Use `pnpm lint` and `pnpm test` to verify your changes before submitting a pull request.
+
+## Design standards
+
+Flora's UI follows the conventions defined in the [style guide](./style-guide.md). Please review it before contributing components or documentation that affects the interface.
+


### PR DESCRIPTION
## Summary
- add basic contributing guide linking to the project style guide
- reference the style guide from the README Contributing section

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/app/api/species/route', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26e731e083249b075a07b87de2d1