### PR TITLE
feat: add plant list and detail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Flora creates personalized care plans and adapts them to your environment.
   - Room assignment & environment tagging
   - Persists new plants to Supabase via API
 
+- 🪴 **Plant API**
+  - List all plants
+  - Fetch individual plant details
+  - Delete plants
+
 - 📅 **Care Dashboard**
   - Today, Overdue, and Upcoming tasks
   - Swipe to mark tasks complete

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,6 +50,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
 
 ### To Build
+- [x] Supabase queries for plant list and detail views
 - [ ] Prisma queries + Supabase writes for logs, photos, and updates
 - [ ] Optimistic updates on log creation
 - [ ] Responsive styling (mobile first, then tablet/desktop)

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,6 +1,26 @@
 import { getCurrentUserId } from "@/lib/auth";
 import { supabaseAdmin } from "../../../../lib/supabaseAdmin";
 
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const userId = getCurrentUserId();
+  const { data, error } = await supabaseAdmin
+    .from("plants")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", userId);
+
+  if (error) {
+    return new Response("Database error", { status: 500 });
+  }
+
+  if (!data || data.length === 0) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(JSON.stringify(data[0]), { status: 200 });
+}
+
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const userId = getCurrentUserId();

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -36,3 +36,17 @@ export async function POST(req: Request) {
 
   return new Response(JSON.stringify(inserted), { status: 200 });
 }
+
+export async function GET(_req: Request) {
+  const userId = getCurrentUserId();
+  const { data, error } = await supabaseAdmin
+    .from("plants")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (error) {
+    return new Response("Database error", { status: 500 });
+  }
+
+  return new Response(JSON.stringify(data), { status: 200 });
+}

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -18,6 +18,12 @@ vi.mock("@supabase/supabase-js", () => ({
           eq: () => Promise.resolve({ error: null }),
         }),
       }),
+      select: () => ({
+        eq: (col: string) =>
+          col === "id"
+            ? { eq: () => Promise.resolve({ data: [{ id: "1" }], error: null }) }
+            : Promise.resolve({ data: [{ id: "1" }], error: null }),
+      }),
     }),
   }),
 }));
@@ -51,6 +57,28 @@ describe("POST /api/plants", () => {
     const req = new Request("http://localhost", { method: "POST", body: form });
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/plants", () => {
+  it("returns list of plants", async () => {
+    const { GET } = await import("../src/app/api/plants/route");
+    const req = new Request("http://localhost", { method: "GET" });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual([{ id: "1" }]);
+  });
+});
+
+describe("GET /api/plants/[id]", () => {
+  it("returns a single plant", async () => {
+    const { GET } = await import("../src/app/api/plants/[id]/route");
+    const req = new Request("http://localhost", { method: "GET" });
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ id: "1" });
   });
 });
 


### PR DESCRIPTION
## Summary
- add GET /api/plants endpoint to list plants for current user
- add GET /api/plants/[id] endpoint to fetch a single plant
- document plant API features and roadmap progress

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find modules for other routes and components)*
- `pnpm test tests/plants.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b8fba788324b93ac5137e4cc7d6