### PR TITLE
feat: redirect to plant detail after adding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Room assignment & environment tagging
   - Persists new plants to Supabase via API
   - Species field is optional with a sensible "Unknown" fallback
+  - Redirects to the plant detail page after creation
 
 - 🪴 **Plant API**
   - List all plants
@@ -27,6 +28,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Swipe to mark tasks complete
 
 - 🪴 **Plant Detail Pages**
+  - Displays plant nickname and species
   - Hero image, Quick Stats, Timeline
   - Notes, Photos, and Coach suggestions
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 
 ### To Finish
  - [x] Submit form → create plant in Supabase
-- [ ] Redirect to `/plants/[id]`
+- [x] Redirect to `/plants/[id]`
  - [x] Fallback when no species selected
 - [ ] Light UI polish: spacing, transitions, preview step
 

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,0 +1,21 @@
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export default async function PlantDetailPage({ params }: { params: { id: string } }) {
+  const { data, error } = await supabaseAdmin
+    .from('plants')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+
+  if (error || !data) {
+    return <div className="p-4">Plant not found</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">{data.name}</h1>
+      <p className="text-muted-foreground">{data.species}</p>
+    </div>
+  );
+}
+

--- a/src/app/plants/new/page.tsx
+++ b/src/app/plants/new/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { SpeciesAutosuggest } from '@/components';
+
+export default function NewPlantPage() {
+  const router = useRouter();
+  const [species, setSpecies] = useState('');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    if (species) {
+      formData.set('species', species);
+    }
+    try {
+      const res = await fetch('/api/plants', {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'x-user-id': 'demo-user',
+        },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const id = Array.isArray(data) ? data[0]?.id : data?.id;
+        if (id) {
+          router.push(`/plants/${id}`);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to create plant', err);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4">
+      <div>
+        <label className="mb-1 block text-sm font-medium" htmlFor="name">
+          Nickname
+        </label>
+        <input
+          id="name"
+          name="name"
+          required
+          className="h-11 w-full rounded-xl border px-3 py-2 text-sm"
+        />
+      </div>
+      <SpeciesAutosuggest value={species} onSelect={setSpecies} />
+      <button
+        type="submit"
+        className="rounded bg-primary px-4 py-2 text-primary-foreground"
+      >
+        Add Plant
+      </button>
+    </form>
+  );
+}
+

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -7,11 +7,11 @@ vi.mock("@/lib/auth", () => ({
   getCurrentUserId: () => "user-123",
 }));
 
-let inserted: any;
+let inserted: Record<string, unknown> | null;
 vi.mock("@supabase/supabase-js", () => ({
   createClient: () => ({
     from: () => ({
-      insert: (payload: any) => {
+      insert: (payload: Record<string, unknown>) => {
         inserted = payload;
         return {
           select: () => Promise.resolve({ data: [payload], error: null }),


### PR DESCRIPTION
## Summary
- add new plant creation page that redirects to the plant detail view
- show basic plant info on a new detail page
- mark roadmap item complete and note redirect in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', others)*

------
https://chatgpt.com/codex/tasks/task_e_68ab46860b488324a0b3d72aecb85c7c