### PR TITLE
feat: add plant collection page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Flora creates personalized care plans and adapts them to your environment.
   - Species field is optional with a sensible "Unknown" fallback
   - Redirects to the plant detail page after creation
 
+- 🗂️ **Plant Collection**
+  - Browse all plants with a grid or list toggle
+  - Friendly empty state prompting you to add your first plant
+
 - 🪴 **Plant API**
   - List all plants
   - Fetch individual plant details

--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { PlantCard } from '@/components';
+
+interface Plant {
+  id: string;
+  name: string;
+  species?: string | null;
+  imageUrl?: string | null;
+}
+
+export default function PlantList({ plants }: { plants: Plant[] }) {
+  const [view, setView] = useState<'grid' | 'list'>('grid');
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-end gap-2">
+        <button
+          aria-label="Grid view"
+          onClick={() => setView('grid')}
+          className={`rounded px-2 py-1 ${view === 'grid' ? 'bg-muted' : ''}`}
+        >
+          Grid
+        </button>
+        <button
+          aria-label="List view"
+          onClick={() => setView('list')}
+          className={`rounded px-2 py-1 ${view === 'list' ? 'bg-muted' : ''}`}
+        >
+          List
+        </button>
+      </div>
+      {view === 'grid' ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {plants.map((plant) => (
+            <PlantCard key={plant.id} plant={plant} />
+          ))}
+        </div>
+      ) : (
+        <ul className="divide-y rounded border">
+          {plants.map((plant) => (
+            <li key={plant.id}>
+              <Link
+                href={`/plants/${plant.id}`}
+                className="flex items-center gap-4 p-2"
+              >
+                {plant.imageUrl ? (
+                  <img
+                    src={plant.imageUrl}
+                    alt={plant.name}
+                    className="h-12 w-12 rounded object-cover"
+                  />
+                ) : (
+                  <div className="h-12 w-12 rounded bg-muted" />
+                )}
+                <div>
+                  <p className="font-medium">{plant.name}</p>
+                  {plant.species && (
+                    <p className="text-sm text-muted-foreground">
+                      {plant.species}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import PlantList from './PlantList';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export default async function PlantsPage() {
+  const { data: plants, error } = await supabaseAdmin
+    .from('plants')
+    .select('*');
+
+  if (error) {
+    return <div className="p-4">Failed to load plants</div>;
+  }
+
+  if (!plants || plants.length === 0) {
+    return (
+      <div className="p-4 text-center">
+        <p className="mb-4">You haven&apos;t added any plants yet.</p>
+        <Link href="/plants/new" className="text-primary underline">
+          Add your first plant
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <PlantList plants={plants} />
+    </div>
+  );
+}
+

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as SpeciesAutosuggest } from './SpeciesAutosuggest';
+export { default as PlantCard } from './plant/PlantCard';

--- a/src/components/plant/PlantCard.tsx
+++ b/src/components/plant/PlantCard.tsx
@@ -1,1 +1,37 @@
-// Placeholder for components/plant/PlantCard.tsx
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface Plant {
+  id: string;
+  name: string;
+  species?: string | null;
+  imageUrl?: string | null;
+}
+
+export default function PlantCard({ plant }: { plant: Plant }) {
+  return (
+    <Link
+      href={`/plants/${plant.id}`}
+      className="block overflow-hidden rounded-lg border"
+    >
+      {plant.imageUrl ? (
+        <Image
+          src={plant.imageUrl}
+          alt={plant.name}
+          width={400}
+          height={300}
+          className="h-40 w-full object-cover"
+        />
+      ) : (
+        <div className="h-40 w-full bg-muted" />
+      )}
+      <div className="p-2">
+        <h3 className="font-semibold">{plant.name}</h3>
+        {plant.species && (
+          <p className="text-sm text-muted-foreground">{plant.species}</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+

--- a/tests/plants.page.test.tsx
+++ b/tests/plants.page.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentUserId: () => 'user-123',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  // eslint-disable-next-line @next/next/no-img-element
+  default: (props: React.ComponentProps<'img'>) => <img {...props} alt={props.alt ?? ''} />,
+}));
+
+vi.mock('@/components', () => ({
+  PlantCard: () => null,
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => Promise.resolve({ data: [], error: null }),
+    }),
+  }),
+}));
+
+describe('PlantsPage', () => {
+  it('shows a friendly empty state when there are no plants', async () => {
+    const PlantsPage = (await import('../src/app/plants/page')).default;
+    const element = await PlantsPage();
+    const html = renderToString(element);
+    expect(html).toContain('Add your first plant');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `/plants` page to browse user plants with grid/list toggle and empty state
- implement `PlantCard` component for plant previews
- document plant collection feature in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts' and related module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d9f76208324ab6a0002015dac6c