### PR TITLE
feat: group plants by room in list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Redirects to the plant detail page after creation
 
 - 🗂️ **Plant Collection**
-  - Browse all plants with a grid or list toggle
+  - Browse plants grouped by room with a grid or list toggle
   - Friendly empty state prompting you to add your first plant
 
 - 🪴 **Plant API**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,10 +36,10 @@ This roadmap outlines upcoming development phases across both functionality and 
 **Goal:** Effortless overview of your collection and details at a glance.
 
 ### `/app/plants`
-- [ ] Grid and list toggle
-- [ ] Group plants by Room
-- [ ] Show photo thumbnails and nicknames
-- [ ] Handle "no plants" state with friendly CTA
+- [x] Grid and list toggle
+- [x] Group plants by Room
+- [x] Show photo thumbnails and nicknames
+- [x] Handle "no plants" state with friendly CTA
 
 ### `/app/plants/[id]`
  - [x] Hero Section: cover photo or placeholder

--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { PlantCard } from '@/components';
 
@@ -9,10 +9,20 @@ interface Plant {
   name: string;
   species?: string | null;
   imageUrl?: string | null;
+  room?: { id: string; name: string } | null;
 }
 
 export default function PlantList({ plants }: { plants: Plant[] }) {
   const [view, setView] = useState<'grid' | 'list'>('grid');
+
+  const grouped = useMemo(() => {
+    return plants.reduce<Record<string, Plant[]>>((acc, plant) => {
+      const roomName = plant.room?.name ?? 'Unassigned';
+      if (!acc[roomName]) acc[roomName] = [];
+      acc[roomName].push(plant);
+      return acc;
+    }, {});
+  }, [plants]);
 
   return (
     <div>
@@ -32,42 +42,47 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
           List
         </button>
       </div>
-      {view === 'grid' ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {plants.map((plant) => (
-            <PlantCard key={plant.id} plant={plant} />
-          ))}
-        </div>
-      ) : (
-        <ul className="divide-y rounded border">
-          {plants.map((plant) => (
-            <li key={plant.id}>
-              <Link
-                href={`/plants/${plant.id}`}
-                className="flex items-center gap-4 p-2"
-              >
-                {plant.imageUrl ? (
-                  <img
-                    src={plant.imageUrl}
-                    alt={plant.name}
-                    className="h-12 w-12 rounded object-cover"
-                  />
-                ) : (
-                  <div className="h-12 w-12 rounded bg-muted" />
-                )}
-                <div>
-                  <p className="font-medium">{plant.name}</p>
-                  {plant.species && (
-                    <p className="text-sm text-muted-foreground">
-                      {plant.species}
-                    </p>
-                  )}
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      {Object.entries(grouped).map(([roomName, roomPlants]) => (
+        <section key={roomName} className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold">{roomName}</h2>
+          {view === 'grid' ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+              {roomPlants.map((plant) => (
+                <PlantCard key={plant.id} plant={plant} />
+              ))}
+            </div>
+          ) : (
+            <ul className="divide-y rounded border">
+              {roomPlants.map((plant) => (
+                <li key={plant.id}>
+                  <Link
+                    href={`/plants/${plant.id}`}
+                    className="flex items-center gap-4 p-2"
+                  >
+                    {plant.imageUrl ? (
+                      <img
+                        src={plant.imageUrl}
+                        alt={plant.name}
+                        className="h-12 w-12 rounded object-cover"
+                      />
+                    ) : (
+                      <div className="h-12 w-12 rounded bg-muted" />
+                    )}
+                    <div>
+                      <p className="font-medium">{plant.name}</p>
+                      {plant.species && (
+                        <p className="text-sm text-muted-foreground">
+                          {plant.species}
+                        </p>
+                      )}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -5,13 +5,22 @@ import { supabaseAdmin } from '@/lib/supabaseAdmin';
 export default async function PlantsPage() {
   const { data: plants, error } = await supabaseAdmin
     .from('plants')
-    .select('*');
+    .select('id, name, species, image_url, room:rooms(id, name)');
 
   if (error) {
     return <div className="p-4">Failed to load plants</div>;
   }
 
-  if (!plants || plants.length === 0) {
+  const mappedPlants =
+    plants?.map((p) => ({
+      id: p.id,
+      name: p.name,
+      species: p.species,
+      imageUrl: p.image_url as string | null,
+      room: p.room as { id: string; name: string } | null,
+    })) ?? [];
+
+  if (mappedPlants.length === 0) {
     return (
       <div className="p-4 text-center">
         <p className="mb-4">You haven&apos;t added any plants yet.</p>
@@ -24,7 +33,7 @@ export default async function PlantsPage() {
 
   return (
     <div className="p-4">
-      <PlantList plants={plants} />
+      <PlantList plants={mappedPlants} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- group plants by room on plants page
- document new grouping in README and roadmap

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts', and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab52fb74c883248a09845b244754e7