### PR TITLE
feat: add plant quick stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Flora creates personalized care plans and adapts them to your environment.
   - Today, Overdue, and Upcoming tasks
   - Swipe to mark tasks complete
 
- - 🪴 **Plant Detail Pages**
-   - Displays plant nickname, species, and hero image
-   - Quick stats, timeline, notes, and coach suggestions *(coming soon)*
+- 🪴 **Plant Detail Pages**
+   - Displays plant nickname, species, hero image, and quick stats
+   - Timeline, notes, and coach suggestions *(coming soon)*
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,11 +43,11 @@ This roadmap outlines upcoming development phases across both functionality and 
 
 ### `/app/plants/[id]`
  - [x] Hero Section: cover photo or placeholder
-- [ ] Quick Stats: next/last watering, schedule, fertilizing
-- [ ] Timeline View: care events sorted by date (styled vertical feed)
-- [ ] Notes: freeform journaling
-- [ ] Gallery: uploaded photos of the plant
-- [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
+ - [x] Quick Stats: next/last watering, schedule, fertilizing
+ - [ ] Timeline View: care events sorted by date (styled vertical feed)
+ - [ ] Notes: freeform journaling
+ - [ ] Gallery: uploaded photos of the plant
+ - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
 
 ### To Build
 - [x] Supabase queries for plant list and detail views

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import QuickStats from '@/components/plant/QuickStats';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const { data: plant, error } = await supabaseAdmin
@@ -43,6 +44,7 @@ export default async function PlantDetailPage({ params }: { params: { id: string
         {plant.species && (
           <p className="text-muted-foreground">{plant.species}</p>
         )}
+        <QuickStats plant={plant} />
       </div>
     </div>
   );

--- a/src/components/plant/QuickStats.tsx
+++ b/src/components/plant/QuickStats.tsx
@@ -1,0 +1,88 @@
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { format, addDays } from 'date-fns';
+
+interface Plant {
+  id: string;
+  water_every?: string | null;
+  waterEvery?: string | null;
+  fert_every?: string | null;
+  fertEvery?: string | null;
+}
+
+interface QuickStatsProps {
+  plant: Plant;
+}
+
+function parseInterval(value?: string | null) {
+  if (!value) return null;
+  const match = value.match(/(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export default async function QuickStats({ plant }: QuickStatsProps) {
+  const { data: waterEvents } = await supabaseAdmin
+    .from('events')
+    .select('created_at')
+    .eq('plant_id', plant.id)
+    .eq('type', 'water')
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const { data: fertEvents } = await supabaseAdmin
+    .from('events')
+    .select('created_at')
+    .eq('plant_id', plant.id)
+    .eq('type', 'fertilize')
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const lastWaterDate = waterEvents?.[0]?.created_at
+    ? new Date(waterEvents[0].created_at as string)
+    : null;
+  const lastFertDate = fertEvents?.[0]?.created_at
+    ? new Date(fertEvents[0].created_at as string)
+    : null;
+
+  const waterInterval = parseInterval(plant.water_every || plant.waterEvery);
+  const fertInterval = parseInterval(plant.fert_every || plant.fertEvery);
+
+  const nextWaterDate =
+    lastWaterDate && waterInterval ? addDays(lastWaterDate, waterInterval) : null;
+  const nextFertDate =
+    lastFertDate && fertInterval ? addDays(lastFertDate, fertInterval) : null;
+
+  const fmt = (d: Date | null) => (d ? format(d, 'PP') : '—');
+
+  return (
+    <div className="mt-4 rounded border p-4">
+      <h2 className="mb-2 text-lg font-semibold">Quick Stats</h2>
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <p className="text-muted-foreground">Water every</p>
+          <p>{plant.water_every || plant.waterEvery || '—'}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Last watered</p>
+          <p>{fmt(lastWaterDate)}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Next watering</p>
+          <p>{fmt(nextWaterDate)}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Fertilize every</p>
+          <p>{plant.fert_every || plant.fertEvery || '—'}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Last fertilized</p>
+          <p>{fmt(lastFertDate)}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Next fertilizing</p>
+          <p>{fmt(nextFertDate)}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add QuickStats component for plant detail pages
- integrate quick stats into plant detail view
- document quick stats in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported in tests/export.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5dfd03cc832495f244026e5369e7