### PR TITLE
feat: add plant care timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Flora creates personalized care plans and adapts them to your environment.
   - Today, Overdue, and Upcoming tasks
   - Swipe to mark tasks complete
 
-- 🪴 **Plant Detail Pages**
-   - Displays plant nickname, species, hero image, and quick stats
-   - Timeline, notes, and coach suggestions *(coming soon)*
+ - 🪴 **Plant Detail Pages**
+   - Displays plant nickname, species, hero image, quick stats, and care timeline
+   - Notes and coach suggestions *(coming soon)*
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 ### `/app/plants/[id]`
  - [x] Hero Section: cover photo or placeholder
  - [x] Quick Stats: next/last watering, schedule, fertilizing
- - [ ] Timeline View: care events sorted by date (styled vertical feed)
+ - [x] Timeline View: care events sorted by date (styled vertical feed)
  - [ ] Notes: freeform journaling
  - [ ] Gallery: uploaded photos of the plant
  - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import QuickStats from '@/components/plant/QuickStats';
+import CareTimeline from '@/components/CareTimeline';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const { data: plant, error } = await supabaseAdmin
@@ -45,6 +46,10 @@ export default async function PlantDetailPage({ params }: { params: { id: string
           <p className="text-muted-foreground">{plant.species}</p>
         )}
         <QuickStats plant={plant} />
+      </div>
+      <div className="p-4">
+        <h2 className="mb-4 text-xl font-semibold">Timeline</h2>
+        <CareTimeline plantId={plant.id} />
       </div>
     </div>
   );

--- a/src/components/CareTimeline.tsx
+++ b/src/components/CareTimeline.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image';
+import { format } from 'date-fns';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface Event {
+  id: string;
+  type: string;
+  note: string | null;
+  image_url: string | null;
+  created_at: string;
+}
+
+export default async function CareTimeline({ plantId }: { plantId: string }) {
+  const { data: events, error } = await supabaseAdmin
+    .from('events')
+    .select('id, type, note, image_url, created_at')
+    .eq('plant_id', plantId)
+    .order('created_at', { ascending: false });
+
+  if (error || !events || events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No care events yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-6 border-l pl-6">
+      {events.map((evt: Event) => (
+        <li key={evt.id} className="relative">{
+          /* timeline dot */
+        }
+          <span className="absolute -left-3 top-2 h-2 w-2 rounded-full bg-primary" />
+          <div className="mb-1 text-xs text-muted-foreground">
+            {format(new Date(evt.created_at), 'MMM d, yyyy')}
+          </div>
+          {evt.type === 'photo' && evt.image_url ? (
+            <Image
+              src={evt.image_url}
+              alt={evt.note ?? evt.type}
+              width={300}
+              height={200}
+              className="rounded-md"
+            />
+          ) : (
+            <p className="font-medium capitalize">{evt.type}</p>
+          )}
+          {evt.note && (
+            <p className="text-sm text-muted-foreground">{evt.note}</p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as SpeciesAutosuggest } from './SpeciesAutosuggest';
 export { default as PlantCard } from './plant/PlantCard';
+export { default as CareTimeline } from './CareTimeline';


### PR DESCRIPTION
## Summary
- add care timeline component for plant detail view
- show timeline on plant detail page and update docs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab5f22e2f083249f7f2422838c05e2