### PR TITLE
feat: add note journaling on plant detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Flora creates personalized care plans and adapts them to your environment.
 
  - 🪴 **Plant Detail Pages**
    - Displays plant nickname, species, hero image, quick stats, and care timeline
-   - Notes and coach suggestions *(coming soon)*
+   - Log personal notes on each plant
+   - Coach suggestions *(coming soon)*
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,7 @@ This roadmap outlines upcoming development phases across both functionality and 
  - [x] Hero Section: cover photo or placeholder
  - [x] Quick Stats: next/last watering, schedule, fertilizing
  - [x] Timeline View: care events sorted by date (styled vertical feed)
- - [ ] Notes: freeform journaling
+ - [x] Notes: freeform journaling
  - [ ] Gallery: uploaded photos of the plant
  - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
 

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import QuickStats from '@/components/plant/QuickStats';
 import CareTimeline from '@/components/CareTimeline';
+import AddNoteForm from '@/components/AddNoteForm';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const { data: plant, error } = await supabaseAdmin
@@ -46,6 +47,10 @@ export default async function PlantDetailPage({ params }: { params: { id: string
           <p className="text-muted-foreground">{plant.species}</p>
         )}
         <QuickStats plant={plant} />
+      </div>
+      <div className="p-4">
+        <h2 className="mb-4 text-xl font-semibold">Add Note</h2>
+        <AddNoteForm plantId={plant.id} />
       </div>
       <div className="p-4">
         <h2 className="mb-4 text-xl font-semibold">Timeline</h2>

--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AddNoteForm({ plantId }: { plantId: string }) {
+  const [note, setNote] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = note.trim();
+    if (!trimmed) return;
+    await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plant_id: plantId, type: 'note', note: trimmed }),
+    });
+    setNote('');
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <textarea
+        className="w-full rounded border p-2 text-sm"
+        placeholder="Write a note..."
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground"
+      >
+        Add Note
+      </button>
+    </form>
+  );
+}

--- a/tests/addnoteform.test.tsx
+++ b/tests/addnoteform.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import AddNoteForm from "../src/components/AddNoteForm";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => undefined }),
+}));
+
+describe("AddNoteForm", () => {
+  it("renders textarea and button", () => {
+    const html = renderToString(<AddNoteForm plantId="1" />);
+    expect(html).toContain("textarea");
+    expect(html).toContain("Add Note");
+  });
+});


### PR DESCRIPTION
## Summary
- allow adding freeform notes to plant detail pages
- document completed notes feature on roadmap and README
- add basic test coverage for note form

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', Cannot find module '../src/components/Navigation', Cannot find module '../src/app/api/ai-care/route', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ab60224ca483249478c1d1a7e9dfcb