### PR TITLE
feat: add events API for notes and photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,18 @@ Flora creates personalized care plans and adapts them to your environment.
   - Fetch individual plant details
   - Delete plants
 
+- 📝 **Events API**
+  - Log notes and photo events for plants
+  - Delete events and associated images
+
 - 📅 **Care Dashboard**
   - Today, Overdue, and Upcoming tasks
   - Swipe to mark tasks complete
 
- - 🪴 **Plant Detail Pages**
-   - Displays plant nickname, species, hero image, quick stats, and care timeline
-   - Log personal notes on each plant
-   - Coach suggestions *(coming soon)*
+- 🪴 **Plant Detail Pages**
+  - Displays plant nickname, species, hero image, quick stats, and care timeline
+  - Log personal notes and photo updates on each plant
+  - Coach suggestions *(coming soon)*
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,31 @@
+import cloudinary from '@/lib/cloudinary';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const id = params.id;
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('events')
+      .select('id, public_id')
+      .eq('id', id)
+      .single();
+    if (error || !data) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    if (data.public_id) {
+      await cloudinary.uploader.destroy(data.public_id);
+    }
+
+    const { error: delError } = await supabaseAdmin
+      .from('events')
+      .delete()
+      .eq('id', id);
+    if (delError) {
+      return new Response('Database error', { status: 500 });
+    }
+    return new Response(null, { status: 200 });
+  } catch (err) {
+    return new Response('Server error', { status: 500 });
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,85 @@
+import cloudinary from '@/lib/cloudinary';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { z } from 'zod';
+
+const jsonSchema = z.object({
+  plant_id: z.string().uuid(),
+  type: z.literal('note'),
+  note: z.string().min(1),
+});
+
+const formSchema = z.object({
+  plant_id: z.string().uuid(),
+  type: z.literal('photo'),
+});
+
+export async function POST(req: Request) {
+  const contentType = req.headers.get('content-type') || '';
+  try {
+    if (contentType.includes('application/json')) {
+      const body = await req.json();
+      const parsed = jsonSchema.safeParse(body);
+      if (!parsed.success) {
+        return new Response('Invalid data', { status: 400 });
+      }
+      const { data, error } = await supabaseAdmin
+        .from('events')
+        .insert({
+          plant_id: parsed.data.plant_id,
+          type: 'note',
+          note: parsed.data.note,
+        })
+        .select();
+      if (error) {
+        return new Response('Database error', { status: 500 });
+      }
+      return new Response(JSON.stringify(data), { status: 200 });
+    }
+
+    const formData = await req.formData();
+    const plant_id = formData.get('plant_id');
+    const type = formData.get('type');
+    const file = formData.get('photo');
+    const parsed = formSchema.safeParse({ plant_id, type });
+    if (!parsed.success || !(file instanceof File)) {
+      return new Response('Invalid data', { status: 400 });
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const upload = await new Promise<{ secure_url: string; public_id: string }>(
+      (resolve, reject) => {
+        const stream = cloudinary.uploader.upload_stream((err, result) => {
+          if (err || !result) return reject(err);
+          resolve({
+            secure_url: result.secure_url,
+            public_id: result.public_id,
+          });
+        });
+        stream.end(buffer);
+      },
+    );
+
+    const { data: inserted, error: insertError } = await supabaseAdmin
+      .from('events')
+      .insert({
+        plant_id: parsed.data.plant_id,
+        type: 'photo',
+        image_url: upload.secure_url,
+        public_id: upload.public_id,
+      })
+      .select();
+    if (insertError) {
+      return new Response('Database error', { status: 500 });
+    }
+
+    await supabaseAdmin
+      .from('plants')
+      .update({ image_url: upload.secure_url })
+      .eq('id', parsed.data.plant_id);
+
+    return new Response(JSON.stringify(inserted), { status: 200 });
+  } catch (err) {
+    return new Response('Server error', { status: 500 });
+  }
+}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,9 @@
+import { v2 as cloudinary } from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+export default cloudinary;


### PR DESCRIPTION
## Summary
- implement events API with Cloudinary uploads and Supabase logging
- allow deleting events and their images
- document Events API and photo notes in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab611ed2888324ac9c53d67eefefc2