### PR TITLE
feat: add plant photo gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Flora creates personalized care plans and adapts them to your environment.
   - Swipe to mark tasks complete
 
 - 🪴 **Plant Detail Pages**
-  - Displays plant nickname, species, hero image, quick stats, and care timeline
-  - Log personal notes and photo updates on each plant
+  - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline
+  - Log personal notes and upload new photos on each plant
   - Coach suggestions *(coming soon)*
 
 - 📷 **Photo Journal**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ This roadmap outlines upcoming development phases across both functionality and 
  - [x] Quick Stats: next/last watering, schedule, fertilizing
  - [x] Timeline View: care events sorted by date (styled vertical feed)
  - [x] Notes: freeform journaling
- - [ ] Gallery: uploaded photos of the plant
+ - [x] Gallery: uploaded photos of the plant
  - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
 
 ### To Build
@@ -114,7 +114,7 @@ This roadmap outlines upcoming development phases across both functionality and 
 - [ ] Swipe to mark care task complete
 - [ ] Watering logic engine based on intervals
 - [x] Prisma `seed.ts` file for demo data
-- [ ] File upload to Cloudinary
+ - [x] File upload to Cloudinary
 - [ ] RLS policies for Supabase
 - [ ] Responsive testing (mobile/tablet/desktop)
 - [ ] Timeline component polish (grouped by date)

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,6 +3,8 @@ import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import QuickStats from '@/components/plant/QuickStats';
 import CareTimeline from '@/components/CareTimeline';
 import AddNoteForm from '@/components/AddNoteForm';
+import AddPhotoForm from '@/components/AddPhotoForm';
+import PhotoGallery from '@/components/PhotoGallery';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const { data: plant, error } = await supabaseAdmin
@@ -51,6 +53,13 @@ export default async function PlantDetailPage({ params }: { params: { id: string
       <div className="p-4">
         <h2 className="mb-4 text-xl font-semibold">Add Note</h2>
         <AddNoteForm plantId={plant.id} />
+      </div>
+      <div className="p-4">
+        <h2 className="mb-4 text-xl font-semibold">Photos</h2>
+        <AddPhotoForm plantId={plant.id} />
+        <div className="mt-4">
+          <PhotoGallery plantId={plant.id} />
+        </div>
       </div>
       <div className="p-4">
         <h2 className="mb-4 text-xl font-semibold">Timeline</h2>

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AddPhotoForm({ plantId }: { plantId: string }) {
+  const [file, setFile] = useState<File | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('plant_id', plantId);
+    formData.append('type', 'photo');
+    formData.append('photo', file);
+    await fetch('/api/events', {
+      method: 'POST',
+      body: formData,
+    });
+    setFile(null);
+    (e.target as HTMLFormElement).reset();
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+      />
+      <button
+        type="submit"
+        className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground"
+      >
+        Upload Photo
+      </button>
+    </form>
+  );
+}

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface PhotoEvent {
+  id: string;
+  image_url: string | null;
+}
+
+export default async function PhotoGallery({ plantId }: { plantId: string }) {
+  const { data: photos, error } = await supabaseAdmin
+    .from('events')
+    .select('id, image_url')
+    .eq('plant_id', plantId)
+    .eq('type', 'photo')
+    .order('created_at', { ascending: false });
+
+  if (error || !photos || photos.length === 0) {
+    return <p className="text-sm text-muted-foreground">No photos yet.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {photos.map((photo: PhotoEvent) => (
+        <Image
+          key={photo.id}
+          src={photo.image_url ?? ''}
+          alt="Plant photo"
+          width={300}
+          height={300}
+          className="h-32 w-full rounded object-cover"
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add client form for uploading plant photos
- display plant photo gallery with Cloudinary-backed images
- document completion of plant gallery in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ab63dccc448324b93c161f69f2ec69