### PR TITLE
Add care coach suggestions to plant detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Flora creates personalized care plans and adapts them to your environment.
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline
   - Log personal notes and upload new photos on each plant
-  - Coach suggestions *(coming soon)*
+  - Coach suggestions highlight overdue watering or fertilizing
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant
 
-- 🧠 **Care Coach** *(Coming Soon)*
-  - AI-based suggestions when care is overdue or inconsistent
+- 🧠 **Care Coach**
+  - Provides suggestions when care is overdue or inconsistent
 
 - 📍 **Environment-aware Schedules**
   - Uses location and weather APIs to adjust care intervals

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ This roadmap outlines upcoming development phases across both functionality and 
  - [x] Timeline View: care events sorted by date (styled vertical feed)
  - [x] Notes: freeform journaling
  - [x] Gallery: uploaded photos of the plant
- - [ ] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
+  - [x] Care Coach: context-aware suggestions (e.g., "Looks overdue for watering")
 
 ### To Build
 - [x] Supabase queries for plant list and detail views

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -5,6 +5,7 @@ import CareTimeline from '@/components/CareTimeline';
 import AddNoteForm from '@/components/AddNoteForm';
 import AddPhotoForm from '@/components/AddPhotoForm';
 import PhotoGallery from '@/components/PhotoGallery';
+import CareCoach from '@/components/plant/CareCoach';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const { data: plant, error } = await supabaseAdmin
@@ -49,6 +50,7 @@ export default async function PlantDetailPage({ params }: { params: { id: string
           <p className="text-muted-foreground">{plant.species}</p>
         )}
         <QuickStats plant={plant} />
+        <CareCoach plant={plant} />
       </div>
       <div className="p-4">
         <h2 className="mb-4 text-xl font-semibold">Add Note</h2>

--- a/src/components/plant/CareCoach.tsx
+++ b/src/components/plant/CareCoach.tsx
@@ -1,0 +1,78 @@
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { addDays } from 'date-fns';
+
+interface Plant {
+  id: string;
+  water_every?: string | null;
+  waterEvery?: string | null;
+  fert_every?: string | null;
+  fertEvery?: string | null;
+}
+
+interface CareCoachProps {
+  plant: Plant;
+}
+
+function parseInterval(value?: string | null) {
+  if (!value) return null;
+  const match = value.match(/(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export default async function CareCoach({ plant }: CareCoachProps) {
+  const { data: waterEvents } = await supabaseAdmin
+    .from('events')
+    .select('created_at')
+    .eq('plant_id', plant.id)
+    .eq('type', 'water')
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const { data: fertEvents } = await supabaseAdmin
+    .from('events')
+    .select('created_at')
+    .eq('plant_id', plant.id)
+    .eq('type', 'fertilize')
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const lastWaterDate = waterEvents?.[0]?.created_at
+    ? new Date(waterEvents[0].created_at as string)
+    : null;
+  const lastFertDate = fertEvents?.[0]?.created_at
+    ? new Date(fertEvents[0].created_at as string)
+    : null;
+
+  const waterInterval = parseInterval(plant.water_every || plant.waterEvery);
+  const fertInterval = parseInterval(plant.fert_every || plant.fertEvery);
+
+  const nextWaterDate =
+    lastWaterDate && waterInterval ? addDays(lastWaterDate, waterInterval) : null;
+  const nextFertDate =
+    lastFertDate && fertInterval ? addDays(lastFertDate, fertInterval) : null;
+
+  const suggestions: string[] = [];
+
+  if (nextWaterDate && nextWaterDate < new Date()) {
+    suggestions.push('Looks overdue for watering.');
+  }
+
+  if (nextFertDate && nextFertDate < new Date()) {
+    suggestions.push('Time to fertilize soon.');
+  }
+
+  if (suggestions.length === 0) {
+    suggestions.push('All good! 🌿');
+  }
+
+  return (
+    <div className="mt-4 rounded border bg-muted/50 p-4">
+      <h2 className="mb-2 text-lg font-semibold">Care Coach</h2>
+      <ul className="list-disc pl-5 text-sm">
+        {suggestions.map((s, i) => (
+          <li key={i}>{s}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement CareCoach server component to flag overdue watering or fertilizing
- show CareCoach on plant detail pages
- document Care Coach completion in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab64ce347483248869dc4cdd04e5bc