### PR TITLE
feat: improve plant page responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Flora creates personalized care plans and adapts them to your environment.
 
 - 🗂️ **Plant Collection**
   - Browse plants grouped by room with a grid or list toggle
+  - Mobile-first responsive layout scales to tablets and desktops
   - Friendly empty state prompting you to add your first plant
 
 - 🪴 **Plant API**
@@ -38,6 +39,7 @@ Flora creates personalized care plans and adapts them to your environment.
 
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline
+  - Responsive layout works across mobile, tablet, and desktop
 - Care timeline groups events by date for a cleaner history
 - Log personal notes, watering/fertilizing events, and upload new photos on each plant
   - New notes and photos appear instantly via optimistic updates

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ This roadmap outlines upcoming development phases across both functionality and 
  - [x] Supabase writes for care logs (water/fertilize)
  - [x] Prisma queries for photos and updates
  - [x] Optimistic updates on log creation
-- [ ] Responsive styling (mobile first, then tablet/desktop)
+- [x] Responsive styling (mobile first, then tablet/desktop)
 
 ---
 

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -9,7 +9,9 @@ import { supabaseAdmin } from '@/lib/supabaseAdmin';
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const plant = await db.plant.findUnique({ where: { id: params.id } });
   if (!plant) {
-    return <div className="p-4">Plant not found</div>;
+    return (
+      <div className="p-4 md:p-6 max-w-md mx-auto">Plant not found</div>
+    );
   }
 
   let heroUrl = plant.imageUrl;
@@ -36,12 +38,12 @@ export default async function PlantDetailPage({ params }: { params: { id: string
           alt={plant.name}
           width={800}
           height={400}
-          className="h-64 w-full object-cover"
+          className="h-64 w-full object-cover md:h-80"
         />
       ) : (
-        <div className="h-64 w-full bg-muted" />
+        <div className="h-64 w-full bg-muted md:h-80" />
       )}
-      <div className="p-4">
+      <div className="p-4 md:p-6 max-w-3xl mx-auto">
         <h1 className="text-2xl font-bold">{plant.name}</h1>
         {plant.species && (
           <p className="text-muted-foreground">{plant.species}</p>
@@ -49,10 +51,10 @@ export default async function PlantDetailPage({ params }: { params: { id: string
         <QuickStats plant={plant} />
         <CareCoach plant={plant} />
       </div>
-      <div className="p-4">
+      <div className="p-4 md:p-6 max-w-3xl mx-auto">
         <EventsSection plantId={plant.id} initialEvents={events ?? []} />
       </div>
-      <div className="p-4">
+      <div className="p-4 md:p-6 max-w-3xl mx-auto">
         <h2 className="mb-4 text-xl font-semibold">Photos</h2>
         <PhotoGallery plantId={plant.id} />
       </div>

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -8,7 +8,9 @@ export default async function PlantsPage() {
     .select('id, name, species, image_url, room:rooms(id, name)');
 
   if (error) {
-    return <div className="p-4">Failed to load plants</div>;
+    return (
+      <div className="p-4 md:p-6 max-w-md mx-auto">Failed to load plants</div>
+    );
   }
 
   const mappedPlants =
@@ -22,7 +24,7 @@ export default async function PlantsPage() {
 
   if (mappedPlants.length === 0) {
     return (
-      <div className="p-4 text-center">
+      <div className="p-4 md:p-6 text-center max-w-md mx-auto">
         <p className="mb-4">You haven&apos;t added any plants yet.</p>
         <Link href="/plants/new" className="text-primary underline">
           Add your first plant
@@ -32,7 +34,7 @@ export default async function PlantsPage() {
   }
 
   return (
-    <div className="p-4">
+    <div className="p-4 md:p-6 max-w-4xl mx-auto">
       <PlantList plants={mappedPlants} />
     </div>
   );


### PR DESCRIPTION
## Summary
- center plant list and detail content for larger screens
- add responsive hero image and sections to plant detail page
- document completed responsive styling in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab873228d08324ad7abde3379db9b2