### PR TITLE
Add basic daily task list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ Flora creates personalized care plans and adapts them to your environment.
   - Log notes, watering, fertilizing, and photo events for plants
   - Delete events and associated images
 
-- 📅 **Care Dashboard**
-  - Today, Overdue, and Upcoming tasks
-  - Swipe to mark tasks complete
+- 📅 **Daily Task List**
+  - Shows upcoming care tasks grouped by date
 
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,1 +1,32 @@
-// Placeholder for app/today/page.tsx
+import TaskList from '@/components/TaskList';
+import type { Task } from '@/types/task';
+
+const sampleTasks: Task[] = [
+  {
+    id: '1',
+    plantName: 'Monstera',
+    type: 'water',
+    due: new Date().toISOString(),
+  },
+  {
+    id: '2',
+    plantName: 'Fiddle Leaf Fig',
+    type: 'fertilize',
+    due: new Date().toISOString(),
+  },
+  {
+    id: '3',
+    plantName: 'Snake Plant',
+    type: 'note',
+    due: new Date(Date.now() + 86400000).toISOString(),
+  },
+];
+
+export default function TodayPage() {
+  return (
+    <section className="p-4">
+      <h1 className="mb-4 text-xl font-semibold">Today&apos;s Tasks</h1>
+      <TaskList tasks={sampleTasks} />
+    </section>
+  );
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { format } from 'date-fns';
+import type { Task } from '@/types/task';
+
+export default function TaskList({ tasks }: { tasks: Task[] }) {
+  if (!tasks || tasks.length === 0) {
+    return <p className="text-sm text-muted-foreground">No tasks for today.</p>;
+  }
+
+  const grouped = tasks.reduce<Record<string, Task[]>>((acc, task) => {
+    const day = format(new Date(task.due), 'PPP');
+    if (!acc[day]) acc[day] = [];
+    acc[day].push(task);
+    return acc;
+  }, {});
+
+  return (
+    <ul className="space-y-8">
+      {Object.entries(grouped).map(([day, dayTasks]) => (
+        <li key={day}>
+          <div className="mb-2 text-sm font-medium text-muted-foreground">{day}</div>
+          <ul className="space-y-4">
+            {dayTasks.map((task) => (
+              <li key={task.id} className="rounded-md border p-4">
+                <p className="font-medium">{task.plantName}</p>
+                <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as SpeciesAutosuggest } from './SpeciesAutosuggest';
 export { default as PlantCard } from './plant/PlantCard';
 export { default as CareTimeline } from './CareTimeline';
 export { default as EventsSection } from './EventsSection';
+export { default as TaskList } from './TaskList';

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,6 @@
+export type Task = {
+  id: string;
+  plantName: string;
+  type: 'water' | 'fertilize' | 'note';
+  due: string; // ISO date string
+};


### PR DESCRIPTION
## Summary
- add `TaskList` component grouping tasks by date
- scaffold `/today` page with sample tasks
- document new daily task list feature in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing modules and undefined hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68ab886fd4e48324abf6fbcbd7ce1c54