### PR TITLE
Add snooze option for daily care tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Flora creates personalized care plans and adapts them to your environment.
 
 - 📅 **Daily Task List**
   - Shows upcoming care tasks grouped by date
-  - Complete tasks directly from the list
+  - Complete or snooze tasks directly from the list
 
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,7 +66,7 @@ All views should adhere to the [style guide](./style-guide.md).
 ### `/app/today`
 - [x] Task List: water/fertilizer/note tasks grouped by date
 - [ ] Swipe right: mark as done
-- [ ] Swipe left: defer/reschedule
+- [x] Snooze tasks to defer/reschedule
 - [x] Quick-add logs from the task
 
 ### Task Engine Logic

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -25,6 +25,20 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
     }
   };
 
+  const handleSnooze = async (id: string, days = 1) => {
+    try {
+      await fetch(`/api/tasks/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'snooze', days }),
+      });
+    } catch (err) {
+      console.error('Failed to snooze task', err);
+    } finally {
+      setTasks((prev) => prev.filter((t) => t.id !== id));
+    }
+  };
+
   const grouped = tasks.reduce<Record<string, Task[]>>((acc, task) => {
     const day = format(new Date(task.due), 'PPP');
     if (!acc[day]) acc[day] = [];
@@ -42,12 +56,20 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
               <li key={task.id} className="rounded-md border p-4">
                 <p className="font-medium">{task.plantName}</p>
                 <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
-                <button
-                  onClick={() => handleComplete(task.id)}
-                  className="mt-2 rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
-                >
-                  Done
-                </button>
+                <div className="mt-2 flex gap-2">
+                  <button
+                    onClick={() => handleComplete(task.id)}
+                    className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
+                  >
+                    Done
+                  </button>
+                  <button
+                    onClick={() => handleSnooze(task.id)}
+                    className="rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground"
+                  >
+                    Snooze
+                  </button>
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- add snooze API call and UI to TaskList so tasks can be deferred
- document snooze capability in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/app/api/ai-care/route' imported from '/workspace/flora/tests/ai-care.api.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68ab915d43d08324a5ad92c216ac7406