### PR TITLE
feat: enable swipe to complete tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Flora creates personalized care plans and adapts them to your environment.
 - 📅 **Daily Task List**
   - Shows upcoming care tasks grouped by date
   - Complete or snooze tasks directly from the list
+  - Swipe right on a task to mark it as done
 
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,7 +65,7 @@ All views should adhere to the [style guide](./style-guide.md).
 
 ### `/app/today`
 - [x] Task List: water/fertilizer/note tasks grouped by date
-- [ ] Swipe right: mark as done
+- [x] Swipe right: mark as done
 - [x] Snooze tasks to defer/reschedule
 - [x] Quick-add logs from the task
 
@@ -114,7 +114,7 @@ All views should adhere to the [style guide](./style-guide.md).
 - [ ] Submit Add Plant form to Supabase
 - [ ] `/plants` grid & list toggle
 - [ ] `/plants/[id]` view with timeline & stats
-- [ ] Swipe to mark care task complete
+- [x] Swipe to mark care task complete
 - [ ] Watering logic engine based on intervals
 - [x] Prisma `seed.ts` file for demo data
  - [x] File upload to Cloudinary

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -53,24 +53,12 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
           <div className="mb-2 text-sm font-medium text-muted-foreground">{day}</div>
           <ul className="space-y-4">
             {dayTasks.map((task) => (
-              <li key={task.id} className="rounded-md border p-4">
-                <p className="font-medium">{task.plantName}</p>
-                <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
-                <div className="mt-2 flex gap-2">
-                  <button
-                    onClick={() => handleComplete(task.id)}
-                    className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
-                  >
-                    Done
-                  </button>
-                  <button
-                    onClick={() => handleSnooze(task.id)}
-                    className="rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground"
-                  >
-                    Snooze
-                  </button>
-                </div>
-              </li>
+              <TaskItem
+                key={task.id}
+                task={task}
+                onComplete={handleComplete}
+                onSnooze={handleSnooze}
+              />
             ))}
           </ul>
         </li>
@@ -78,3 +66,63 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
     </ul>
   );
 }
+
+type TaskItemProps = {
+  task: Task;
+  onComplete: (id: string) => Promise<void> | void;
+  onSnooze: (id: string, days?: number) => Promise<void> | void;
+};
+
+function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
+  const [startX, setStartX] = useState<number | null>(null);
+  const [offsetX, setOffsetX] = useState(0);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLLIElement>) => {
+    setStartX(e.clientX);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLLIElement>) => {
+    if (startX !== null) {
+      const delta = e.clientX - startX;
+      if (delta > 0) setOffsetX(delta);
+    }
+  };
+
+  const handlePointerEnd = () => {
+    if (offsetX > 100) {
+      void onComplete(task.id);
+    }
+    setStartX(null);
+    setOffsetX(0);
+  };
+
+  return (
+    <li
+      className="rounded-md border p-4 transition-transform"
+      style={{ transform: `translateX(${offsetX}px)`, touchAction: 'pan-y' }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerLeave={startX !== null ? handlePointerEnd : undefined}
+      onPointerCancel={handlePointerEnd}
+    >
+      <p className="font-medium">{task.plantName}</p>
+      <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
+      <div className="mt-2 flex gap-2">
+        <button
+          onClick={() => onComplete(task.id)}
+          className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
+        >
+          Done
+        </button>
+        <button
+          onClick={() => onSnooze(task.id)}
+          className="rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground"
+        >
+          Snooze
+        </button>
+      </div>
+    </li>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add swipe-to-complete interaction on daily task items
- document swipe completion in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing modules and undefined hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68ab925fb6a88324865fcfc9a2b36b1f