### PR TITLE
feat: add timezone-aware task scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Shows upcoming care tasks grouped by date
   - Complete or snooze tasks directly from the list
   - Swipe right on a task to mark it as done
+  - Timezone-aware scheduling keeps tasks aligned with your local day
 
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,7 +73,7 @@ All views should adhere to the [style guide](./style-guide.md).
 - [ ] Use `waterEvery` and `fertEvery` intervals
 - [ ] Schedule CareEvents per plant
 - [ ] Hydrate timeline from completed + upcoming tasks
-- [ ] Timezone-aware comparisons (`dayjs` or `date-fns`)
+- [x] Timezone-aware comparisons (`dayjs` or `date-fns`)
 
 ### AI Enhancements
 - [ ] Coach suggests “you may want to water early due to low humidity”

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,6 +1,7 @@
 import { getCurrentUserId } from '@/lib/auth';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { logEvent } from '@/lib/analytics';
+import { addDays, formatISO, parseISO } from 'date-fns';
 
 interface Params {
   params: { id: string };
@@ -48,9 +49,8 @@ export async function PATCH(req: Request, { params }: Params) {
       return new Response('Task not found', { status: 404 });
     }
 
-    const due = new Date(task.due_date as string);
-    due.setDate(due.getDate() + days);
-    const newDue = due.toISOString().slice(0, 10);
+    const due = parseISO(task.due_date as string);
+    const newDue = formatISO(addDays(due, days), { representation: 'date' });
 
     const { error: updateError } = await supabaseAdmin
       .from('tasks')

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import type { Task } from '@/types/task';
 
 export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
@@ -40,7 +40,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
   };
 
   const grouped = tasks.reduce<Record<string, Task[]>>((acc, task) => {
-    const day = format(new Date(task.due), 'PPP');
+    const day = format(parseISO(task.due), 'PPP');
     if (!acc[day]) acc[day] = [];
     acc[day].push(task);
     return acc;


### PR DESCRIPTION
## Summary
- handle task snoozing with date-fns for timezone-aware due dates
- parse ISO dates in TaskList for accurate grouping
- document timezone-aware scheduling and mark roadmap item complete

## Testing
- `pnpm test tests/tasks.api.test.ts` *(fails: Cannot find package '@/lib/supabaseAdmin')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9397b2348324827182126964259f