### PR TITLE
feat: schedule tasks from care intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Delete events and associated images
 
 - 📅 **Daily Task List**
+  - Generates tasks from each plant's `waterEvery` and `fertEvery` intervals
   - Shows upcoming care tasks grouped by date
   - Complete or snooze tasks directly from the list
   - Swipe right on a task to mark it as done

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,32 +1,27 @@
 import TaskList from '@/components/TaskList';
-import type { Task } from '@/types/task';
+import { generateTasks } from '@/lib/tasks';
 
-const sampleTasks: Task[] = [
+const samplePlants = [
   {
     id: '1',
-    plantName: 'Monstera',
-    type: 'water',
-    due: new Date().toISOString(),
+    name: 'Monstera',
+    waterEvery: '7 days',
+    lastWateredAt: new Date(Date.now() - 8 * 86400000).toISOString(),
   },
   {
     id: '2',
-    plantName: 'Fiddle Leaf Fig',
-    type: 'fertilize',
-    due: new Date().toISOString(),
-  },
-  {
-    id: '3',
-    plantName: 'Snake Plant',
-    type: 'note',
-    due: new Date(Date.now() + 86400000).toISOString(),
+    name: 'Fiddle Leaf Fig',
+    fertEvery: '30 days',
+    lastFertilizedAt: new Date(Date.now() - 31 * 86400000).toISOString(),
   },
 ];
 
 export default function TodayPage() {
+  const tasks = generateTasks(samplePlants);
   return (
     <section className="p-4">
       <h1 className="mb-4 text-xl font-semibold">Today&apos;s Tasks</h1>
-      <TaskList tasks={sampleTasks} />
+      <TaskList tasks={tasks} />
     </section>
   );
 }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,0 +1,51 @@
+import { addDays, formatISO, parseISO } from 'date-fns';
+import type { Task } from '@/types/task';
+
+interface Plant {
+  id: string;
+  name: string;
+  waterEvery?: string | null;
+  fertEvery?: string | null;
+  lastWateredAt?: string | null; // ISO date string
+  lastFertilizedAt?: string | null; // ISO date string
+}
+
+function parseInterval(value?: string | null): number | null {
+  if (!value) return null;
+  const match = value.match(/(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export function generateTasks(plants: Plant[], today: Date = new Date()): Task[] {
+  const tasks: Task[] = [];
+
+  for (const plant of plants) {
+    const waterInterval = parseInterval(plant.waterEvery);
+    if (waterInterval !== null && plant.lastWateredAt) {
+      const due = addDays(parseISO(plant.lastWateredAt), waterInterval);
+      if (due <= today) {
+        tasks.push({
+          id: `${plant.id}-water`,
+          plantName: plant.name,
+          type: 'water',
+          due: formatISO(due),
+        });
+      }
+    }
+
+    const fertInterval = parseInterval(plant.fertEvery);
+    if (fertInterval !== null && plant.lastFertilizedAt) {
+      const due = addDays(parseISO(plant.lastFertilizedAt), fertInterval);
+      if (due <= today) {
+        tasks.push({
+          id: `${plant.id}-fertilize`,
+          plantName: plant.name,
+          type: 'fertilize',
+          due: formatISO(due),
+        });
+      }
+    }
+  }
+
+  return tasks.sort((a, b) => a.due.localeCompare(b.due));
+}

--- a/tests/taskEngine.test.ts
+++ b/tests/taskEngine.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { generateTasks } from '../src/lib/tasks';
+
+describe('generateTasks', () => {
+  it('creates a water task when interval has passed', () => {
+    const plants = [
+      {
+        id: '1',
+        name: 'Monstera',
+        waterEvery: '7 days',
+        lastWateredAt: '2024-01-01',
+      },
+    ];
+    const tasks = generateTasks(plants, new Date('2024-01-08'));
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({ plantName: 'Monstera', type: 'water' });
+  });
+
+  it('skips tasks that are not yet due', () => {
+    const plants = [
+      {
+        id: '1',
+        name: 'Monstera',
+        waterEvery: '7 days',
+        lastWateredAt: '2024-01-05',
+      },
+    ];
+    const tasks = generateTasks(plants, new Date('2024-01-08'));
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('creates a fertilize task when interval has passed', () => {
+    const plants = [
+      {
+        id: '1',
+        name: 'Fern',
+        fertEvery: '30 days',
+        lastFertilizedAt: '2024-01-01',
+      },
+    ];
+    const tasks = generateTasks(plants, new Date('2024-02-01'));
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({ plantName: 'Fern', type: 'fertilize' });
+  });
+});


### PR DESCRIPTION
## Summary
- generate tasks from plant care intervals
- use task generator on Today page
- document interval-based scheduling in README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/app/api/ai-care/route' imported from '/workspace/flora/tests/ai-care.api.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68ab94fce0f4832492e2bfba7ff1d6a1