### PR TITLE
feat: parse schedule intervals with units

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Flora creates personalized care plans and adapts them to your environment.
 
 - 📅 **Daily Task List**
   - Generates tasks from each plant's `waterEvery` and `fertEvery` intervals
+  - Supports intervals defined in days, weeks, months, or years
   - Shows upcoming care tasks grouped by date
   - Complete or snooze tasks directly from the list
   - Swipe right on a task to mark it as done

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,7 +70,7 @@ All views should adhere to the [style guide](./style-guide.md).
 - [x] Quick-add logs from the task
 
 ### Task Engine Logic
-- [ ] Use `waterEvery` and `fertEvery` intervals
+- [x] Use `waterEvery` and `fertEvery` intervals
 - [ ] Schedule CareEvents per plant
 - [ ] Hydrate timeline from completed + upcoming tasks
 - [x] Timezone-aware comparisons (`dayjs` or `date-fns`)

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -12,8 +12,27 @@ interface Plant {
 
 function parseInterval(value?: string | null): number | null {
   if (!value) return null;
-  const match = value.match(/(\d+)/);
-  return match ? parseInt(match[1], 10) : null;
+
+  const match = value
+    .toLowerCase()
+    .match(/(\d+)\s*(day|week|month|year)s?/);
+  if (!match) return null;
+
+  const quantity = parseInt(match[1], 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case 'day':
+      return quantity;
+    case 'week':
+      return quantity * 7;
+    case 'month':
+      return quantity * 30;
+    case 'year':
+      return quantity * 365;
+    default:
+      return null;
+  }
 }
 
 export function generateTasks(plants: Plant[], today: Date = new Date()): Task[] {

--- a/tests/taskEngine.test.ts
+++ b/tests/taskEngine.test.ts
@@ -42,4 +42,18 @@ describe('generateTasks', () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({ plantName: 'Fern', type: 'fertilize' });
   });
+
+  it('handles week-based intervals', () => {
+    const plants = [
+      {
+        id: '1',
+        name: 'Rose',
+        waterEvery: '2 weeks',
+        lastWateredAt: '2024-01-01',
+      },
+    ];
+    const tasks = generateTasks(plants, new Date('2024-01-15'));
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({ plantName: 'Rose', type: 'water' });
+  });
 });


### PR DESCRIPTION
## Summary
- support day/week/month/year units when parsing care intervals
- document interval units in README
- mark task engine interval work complete in roadmap

## Testing
- `pnpm test tests/taskEngine.test.ts`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts', Cannot find package '@/lib/supabaseAdmin' imported from '/workspace/flora/src/app/api/tasks/[id]/route.ts', and more)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab9624bfc883249d96240c0306bbb8