### PR TITLE
feat: hydrate plant timelines with upcoming tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Flora creates personalized care plans and adapts them to your environment.
 - 🪴 **Plant Detail Pages**
   - Displays plant nickname, species, hero image, quick stats, photo gallery, and care timeline
   - Responsive layout works across mobile, tablet, and desktop
-- Care timeline groups events by date for a cleaner history
+- Care timeline groups events by date and shows upcoming watering or fertilizing tasks
 - Log personal notes, watering/fertilizing events, and upload new photos on each plant
   - New notes and photos appear instantly via optimistic updates
 - Coach suggestions highlight overdue watering or fertilizing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,7 +72,7 @@ All views should adhere to the [style guide](./style-guide.md).
 ### Task Engine Logic
 - [x] Use `waterEvery` and `fertEvery` intervals
 - [x] Schedule CareEvents per plant
-- [ ] Hydrate timeline from completed + upcoming tasks
+ - [x] Hydrate timeline from completed + upcoming tasks
 - [x] Timezone-aware comparisons (`dayjs` or `date-fns`)
 
 ### AI Enhancements

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -5,6 +5,7 @@ import PhotoGallery from '@/components/PhotoGallery';
 import CareCoach from '@/components/plant/CareCoach';
 import EventsSection from '@/components/EventsSection';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { hydrateTimeline } from '@/lib/tasks';
 
 export default async function PlantDetailPage({ params }: { params: { id: string } }) {
   const plant = await db.plant.findUnique({ where: { id: params.id } });
@@ -30,6 +31,12 @@ export default async function PlantDetailPage({ params }: { params: { id: string
     .eq('plant_id', plant.id)
     .order('created_at', { ascending: false });
 
+  const timelineEvents = hydrateTimeline(events ?? [], {
+    id: plant.id,
+    waterEvery: plant.waterEvery,
+    fertEvery: plant.fertEvery,
+  });
+
   return (
     <div>
       {heroUrl ? (
@@ -52,7 +59,7 @@ export default async function PlantDetailPage({ params }: { params: { id: string
         <CareCoach plant={plant} />
       </div>
       <div className="p-4 md:p-6 max-w-3xl mx-auto">
-        <EventsSection plantId={plant.id} initialEvents={events ?? []} />
+        <EventsSection plantId={plant.id} initialEvents={timelineEvents} />
       </div>
       <div className="p-4 md:p-6 max-w-3xl mx-auto">
         <h2 className="mb-4 text-xl font-semibold">Photos</h2>

--- a/tests/taskEngine.test.ts
+++ b/tests/taskEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { generateTasks } from '../src/lib/tasks';
+import { generateTasks, hydrateTimeline } from '../src/lib/tasks';
+import type { CareEvent } from '../src/types';
 
 describe('generateTasks', () => {
   it('creates a water task when interval has passed', () => {
@@ -55,5 +56,26 @@ describe('generateTasks', () => {
     const tasks = generateTasks(plants, new Date('2024-01-15'));
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({ plantName: 'Rose', type: 'water' });
+  });
+});
+
+describe('hydrateTimeline', () => {
+  it('adds upcoming care events based on intervals', () => {
+    const events: CareEvent[] = [
+      {
+        id: '1',
+        type: 'water',
+        note: null,
+        image_url: null,
+        created_at: '2024-01-01',
+      },
+    ];
+    const timeline = hydrateTimeline(events, {
+      id: 'plant1',
+      waterEvery: '7 days',
+      fertEvery: null,
+    });
+    const hasUpcoming = timeline.some((e) => e.type === 'water due');
+    expect(hasUpcoming).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- merge past care events with upcoming watering and fertilizing tasks
- display combined timeline on plant detail page
- document timeline hydration in roadmap and README

## Testing
- `pnpm test` *(fails: ReferenceError beforeEach is not defined; missing modules '@/components/EventsSection', '@/lib/supabaseAdmin', '../src/lib/csv', '../src/components/Navigation', '../src/app/api/ai-care/route', '../src/app/api/care-feedback/route', '@/lib/supabaseAdmin')*

------
https://chatgpt.com/codex/tasks/task_e_68ab9891648c83249ea2a03a4bc26051