### PR TITLE
feat: coach warns on low humidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Flora creates personalized care plans and adapts them to your environment.
 - Care timeline groups events by date and shows upcoming watering or fertilizing tasks
 - Log personal notes, watering/fertilizing events, and upload new photos on each plant
   - New notes and photos appear instantly via optimistic updates
-- Coach suggestions highlight overdue watering or fertilizing
+  - Coach suggestions highlight overdue watering, fertilizing, and low humidity warnings
 
 - 📷 **Photo Journal**
   - Upload progress photos for each plant
 
 - 🧠 **Care Coach**
-  - Provides suggestions when care is overdue or inconsistent
+  - Provides suggestions when care is overdue, humidity is low, or habits are inconsistent
 
 - 📍 **Environment-aware Schedules**
   - Uses location and weather APIs to adjust care intervals

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -76,7 +76,7 @@ All views should adhere to the [style guide](./style-guide.md).
 - [x] Timezone-aware comparisons (`dayjs` or `date-fns`)
 
 ### AI Enhancements
-- [ ] Coach suggests “you may want to water early due to low humidity”
+- [x] Coach suggests “you may want to water early due to low humidity”
 - [ ] Long-term: ET₀ model integration
 
 ---

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Plant {
   waterAmount   String?
   fertEvery     String?
   fertFormula   String?
+  humidity      String?
 
   // relationships
   room          Room?    @relation(fields: [roomId], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -28,6 +28,7 @@ async function main() {
       waterAmount: "250ml",
       fertEvery: "30 days",
       fertFormula: "10-10-10",
+      humidity: "medium",
       careEvents: {
         create: [
           { type: "water", date: new Date() },
@@ -42,6 +43,7 @@ async function main() {
       species: "Carnegiea gigantea",
       roomId: kitchen.id,
       waterEvery: "14 days",
+      humidity: "low",
       careEvents: {
         create: [
           { type: "water", date: new Date() },

--- a/src/components/plant/CareCoach.tsx
+++ b/src/components/plant/CareCoach.tsx
@@ -7,6 +7,7 @@ interface Plant {
   waterEvery?: string | null;
   fert_every?: string | null;
   fertEvery?: string | null;
+  humidity?: string | null;
 }
 
 interface CareCoachProps {
@@ -52,6 +53,10 @@ export default async function CareCoach({ plant }: CareCoachProps) {
     lastFertDate && fertInterval ? addDays(lastFertDate, fertInterval) : null;
 
   const suggestions: string[] = [];
+
+  if (plant.humidity && plant.humidity.toLowerCase() === 'low') {
+    suggestions.push('You may want to water early due to low humidity.');
+  }
 
   if (nextWaterDate && nextWaterDate < new Date()) {
     suggestions.push('Looks overdue for watering.');

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -17,6 +17,7 @@ create table if not exists public.plants (
   soil_type text,
   light_level text,
   indoor text,
+  humidity text,
   image_url text,
   care_plan jsonb,
   created_at timestamptz default now()
@@ -32,6 +33,7 @@ alter table if exists public.plants add column if not exists drainage text;
 alter table if exists public.plants add column if not exists soil_type text;
 alter table if exists public.plants add column if not exists light_level text;
 alter table if exists public.plants add column if not exists indoor text;
+alter table if exists public.plants add column if not exists humidity text;
 alter table if exists public.plants add column if not exists user_id text not null default 'flora-single-user';
 
 -- Species table


### PR DESCRIPTION
## Summary
- extend CareCoach with low-humidity warnings
- store humidity on plants via Prisma schema and Supabase SQL
- document humidity-aware coaching in README and roadmap

## Testing
- `pnpm lint`
- `pnpm prisma generate` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' ... and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9c7d314083249715903466b3a244