### PR TITLE
feat: celebrate task completion with confetti

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Complete or snooze tasks directly from the list
   - Completing a task automatically logs a care event on the plant
   - Swipe right on a task to mark it as done
+  - Celebrate completed tasks with a burst of confetti
   - Timezone-aware scheduling keeps tasks aligned with your local day
 
 - 🪴 **Plant Detail Pages**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,7 +87,7 @@ All views should adhere to the [style guide](./style-guide.md).
 **Goal:** Feel good using it.
 
 ### Design Tweaks
-- [ ] Animate “Mark as Done” feedback (confetti, pulse, or sparkles)
+- [x] Animate “Mark as Done” feedback (confetti, pulse, or sparkles)
 - [ ] Variable font-weight pulsing on active tasks
 - [ ] Swipe card transitions
 - [ ] Soothing sound on task complete (optional)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@supabase/supabase-js": "^2.55.0",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "^2.7.0",
     "clsx": "^2.1.1",
@@ -63,8 +64,7 @@
     "tw-animate-css": "^1.3.7",
     "typescript": "^5",
     "vitest": "^3.2.4"
-  }
-  ,
+  },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.55.0
         version: 2.55.0
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1830,6 +1833,9 @@ packages:
 
   caniuse-lite@1.0.30001735:
     resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
+
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -5178,6 +5184,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001735: {}
+
+  canvas-confetti@1.9.3: {}
 
   ccount@2.0.1: {}
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from 'react';
+import confetti from 'canvas-confetti';
 import { format, parseISO } from 'date-fns';
 import type { Task } from '@/types/task';
 
@@ -21,6 +22,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
     } catch (err) {
       console.error('Failed to complete task', err);
     } finally {
+      confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
       setTasks((prev) => prev.filter((t) => t.id !== id));
     }
   };


### PR DESCRIPTION
## Summary
- add canvas-confetti dependency for visual celebrations
- trigger confetti when completing a care task
- note completion animation in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts', Cannot find package '@/lib/supabaseAdmin', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9db666708324b8682d4dee1b7534