### PR TITLE
feat: pulse active tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Completing a task automatically logs a care event on the plant
   - Swipe right on a task to mark it as done
   - Celebrate completed tasks with a burst of confetti
+  - Active tasks gently pulse with a variable font weight animation
   - Timezone-aware scheduling keeps tasks aligned with your local day
 
 - 🪴 **Plant Detail Pages**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,7 +88,7 @@ All views should adhere to the [style guide](./style-guide.md).
 
 ### Design Tweaks
 - [x] Animate “Mark as Done” feedback (confetti, pulse, or sparkles)
-- [ ] Variable font-weight pulsing on active tasks
+ - [x] Variable font-weight pulsing on active tasks
 - [ ] Swipe card transitions
 - [ ] Soothing sound on task complete (optional)
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -108,7 +108,7 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
       onPointerLeave={startX !== null ? handlePointerEnd : undefined}
       onPointerCancel={handlePointerEnd}
     >
-      <p className="font-medium">{task.plantName}</p>
+      <p className="font-medium animate-pulse-weight">{task.plantName}</p>
       <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
       <div className="mt-2 flex gap-2">
         <button

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -48,6 +48,15 @@ export default {
       boxShadow: {
         card: "0 4px 6px -1px rgba(0,0,0,0.05)",
       },
+      keyframes: {
+        "pulse-weight": {
+          "0%, 100%": { fontWeight: "500" },
+          "50%": { fontWeight: "700" },
+        },
+      },
+      animation: {
+        "pulse-weight": "pulse-weight 1s ease-in-out infinite",
+      },
     },
   },
   plugins: [animate],


### PR DESCRIPTION
## Summary
- add variable font-weight pulse animation for active tasks
- document pulsing tasks in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing modules and undefined hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1078d688324a5c22410cabdf798