### PR TITLE
feat: add swipe card transitions for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Complete or snooze tasks directly from the list
   - Completing a task automatically logs a care event on the plant
   - Swipe right on a task to mark it as done
+  - Cards slide away with a smooth transition when completed
   - Celebrate completed tasks with a burst of confetti
   - Active tasks gently pulse with a variable font weight animation
   - Timezone-aware scheduling keeps tasks aligned with your local day

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,7 +89,7 @@ All views should adhere to the [style guide](./style-guide.md).
 ### Design Tweaks
 - [x] Animate “Mark as Done” feedback (confetti, pulse, or sparkles)
  - [x] Variable font-weight pulsing on active tasks
-- [ ] Swipe card transitions
+- [x] Swipe card transitions
 - [ ] Soothing sound on task complete (optional)
 
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -78,6 +78,7 @@ type TaskItemProps = {
 function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
   const [startX, setStartX] = useState<number | null>(null);
   const [offsetX, setOffsetX] = useState(0);
+  const [removing, setRemoving] = useState(false);
 
   const handlePointerDown = (e: React.PointerEvent<HTMLLIElement>) => {
     setStartX(e.clientX);
@@ -90,9 +91,16 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
     }
   };
 
+  const triggerComplete = () => {
+    setRemoving(true);
+    setTimeout(() => {
+      void onComplete(task.id);
+    }, 300);
+  };
+
   const handlePointerEnd = () => {
     if (offsetX > 100) {
-      void onComplete(task.id);
+      triggerComplete();
     }
     setStartX(null);
     setOffsetX(0);
@@ -100,8 +108,14 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
 
   return (
     <li
-      className="rounded-md border p-4 transition-transform"
-      style={{ transform: `translateX(${offsetX}px)`, touchAction: 'pan-y' }}
+      className="rounded-md border p-4 transition-all duration-300"
+      style={{
+        transform: removing
+          ? 'translateX(100%)'
+          : `translateX(${offsetX}px)`,
+        opacity: removing ? 0 : 1,
+        touchAction: 'pan-y',
+      }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
@@ -112,7 +126,7 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
       <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
       <div className="mt-2 flex gap-2">
         <button
-          onClick={() => onComplete(task.id)}
+          onClick={triggerComplete}
           className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground"
         >
           Done


### PR DESCRIPTION
## Summary
- animate task cards sliding out when completed by swipe or button
- mark swipe card transitions as completed in roadmap
- document smooth slide-away animation in README

## Testing
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', missing test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aba36a116883248b31a6cdd27fb1d6