### PR TITLE
feat: play chime when completing tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Flora creates personalized care plans and adapts them to your environment.
   - Swipe right on a task to mark it as done
   - Cards slide away with a smooth transition when completed
   - Celebrate completed tasks with a burst of confetti
+  - Optional soothing chime plays when marking tasks complete
   - Active tasks gently pulse with a variable font weight animation
   - Timezone-aware scheduling keeps tasks aligned with your local day
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,7 +90,7 @@ All views should adhere to the [style guide](./style-guide.md).
 - [x] Animate “Mark as Done” feedback (confetti, pulse, or sparkles)
  - [x] Variable font-weight pulsing on active tasks
 - [x] Swipe card transitions
-- [ ] Soothing sound on task complete (optional)
+- [x] Soothing sound on task complete (optional)
 
 
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -5,6 +5,26 @@ import confetti from 'canvas-confetti';
 import { format, parseISO } from 'date-fns';
 import type { Task } from '@/types/task';
 
+function playChime() {
+  if (typeof window === 'undefined') return;
+  const AudioCtx =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext: typeof AudioContext })
+      .webkitAudioContext;
+  const ctx = new AudioCtx();
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(660, ctx.currentTime);
+  gain.gain.setValueAtTime(0.1, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 1);
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + 1);
+  oscillator.onended = () => ctx.close();
+}
+
 export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
   const [tasks, setTasks] = useState(initialTasks);
 
@@ -23,6 +43,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
       console.error('Failed to complete task', err);
     } finally {
       confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
+      playChime();
       setTasks((prev) => prev.filter((t) => t.id !== id));
     }
   };


### PR DESCRIPTION
## Summary
- add Web Audio API chime when marking a task complete
- document completion chime in roadmap and README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find modules in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aba436ecc88324939fe1d1fab392f3