### PR TITLE
Add navigation component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Flora creates personalized care plans and adapts them to your environment.
   - Caches species lookups to reduce repeated OpenAI requests
   - Preview plant details before creation
 
+- 🧭 **Navigation**
+  - Quick links to home, plant list, and add form
+  - Highlights the current page for accessibility
+
 - 🗂️ **Plant Collection**
   - Browse plants grouped by room with a grid or list toggle
   - Mobile-first responsive layout scales to tablets and desktops

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+// Ensure React is available when components are rendered in tests
+(globalThis as unknown as { React?: typeof React }).React ??= React;
+
+interface NavLink {
+  href: string;
+  label: string;
+}
+
+const links: NavLink[] = [
+  { href: '/', label: 'Home' },
+  { href: '/plants', label: 'Plants' },
+  { href: '/add', label: 'Add' },
+];
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Main" className="flex gap-4">
+      {links.map(({ href, label }) => (
+        <Link key={href} href={href} aria-current={pathname === href ? 'page' : undefined}>
+          {label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as PlantCard } from './plant/PlantCard';
 export { default as CareTimeline } from './CareTimeline';
 export { default as EventsSection } from './EventsSection';
 export { default as TaskList } from './TaskList';
+export { default as Navigation } from './Navigation';


### PR DESCRIPTION
## Summary
- implement Navigation component with active route highlighting for Home, Plants, and Add pages
- document navigation feature in README and export component from central index

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv'; ReferenceError: beforeEach is not defined; Cannot find package '@/lib/supabaseAdmin'; Cannot find module '../src/app/api/ai-care/route'; Cannot find module '../src/app/api/care-feedback/route'; Cannot find package '@/components/EventsSection')*

------
https://chatgpt.com/codex/tasks/task_e_68aba4f0e0b08324a500260ee585fdc6