### PR TITLE
feat: add default home page component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,13 @@
-// Placeholder for app/page.tsx
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="p-4 md:p-6 max-w-md mx-auto text-center">
+      <h1 className="text-2xl font-bold mb-4">Welcome to Flora</h1>
+      <p className="mb-4">Your personal plant care companion.</p>
+      <Link href="/plants/new" className="text-primary underline">
+        Add your first plant
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple home page so Next.js has a valid default export

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find modules and beforeEach undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68aba669c03883249d2b87c79ff43be0