### PR TITLE
fix: add analytics opt-out attribute to RootLayout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" data-google-analytics-opt-out="">
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add `data-google-analytics-opt-out` to `<html>` in RootLayout to avoid hydration mismatch

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aba71a67308324b6f20a68f41ba0d2