### PR TITLE
Handle missing OpenAI key in species search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Flora creates personalized care plans and adapts them to your environment.
 
 - 🌱 **Add a Plant**
   - Smart species autosuggest (via OpenAI API)
+    - Falls back to empty results if `OPENAI_API_KEY` is missing
   - Auto-generated AI care plan
   - Room assignment & environment tagging
   - Persists new plants to Supabase via API
@@ -97,7 +98,7 @@ All schema, policies, and seed data live as SQL in [`/supabase`](./supabase).
 
 ## 📦 Setup
 
-Copy `.env.example` to `.env.local` and fill in your Supabase, OpenAI, Cloudinary, and optional auth credentials.
+Copy `.env.example` to `.env.local` and fill in your Supabase, OpenAI (optional), Cloudinary, and optional auth credentials. Without an `OPENAI_API_KEY`, species suggestions and other AI features are disabled.
 
 ```bash
 git clone https://github.com/osmond/flora.git

--- a/src/app/api/species/route.ts
+++ b/src/app/api/species/route.ts
@@ -39,10 +39,8 @@ export async function GET(request: Request) {
 
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
-    return NextResponse.json(
-      { error: 'OPENAI_API_KEY is not configured' },
-      { status: 500 }
-    );
+    console.warn('OPENAI_API_KEY is not configured; returning empty species list');
+    return NextResponse.json([]);
   }
 
   try {

--- a/tests/species.api.test.ts
+++ b/tests/species.api.test.ts
@@ -9,6 +9,25 @@ describe("GET /api/species", () => {
     vi.resetModules();
   });
 
+  it("returns empty array when OPENAI_API_KEY is missing", async () => {
+    const originalKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { GET } = await import("../src/app/api/species/route");
+
+    const req = new Request("http://localhost/api/species?q=rose");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env.OPENAI_API_KEY = originalKey;
+  });
+
   it("returns cached results for repeated queries", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo) => {
       if (typeof input === "string" && input.includes("api.openai.com")) {


### PR DESCRIPTION
## Summary
- return an empty list when `OPENAI_API_KEY` is missing instead of a 500
- document and test the missing-key fallback

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv' imported from '/workspace/flora/tests/export.test.ts', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aba8de31e48324a452658f1aeed397