### PR TITLE
feat: apply Inter font globally

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,7 @@
   --ring: 166 27% 43%;
   --destructive: 0 72% 50%;
   --destructive-foreground: 0 0% 98%;
+  --font-inter: 'Inter', sans-serif;
 }
 
 .dark {
@@ -38,4 +39,8 @@
   --ring: 166 30% 51%;
   --destructive: 0 70% 58%;
   --destructive-foreground: 0 0% 98%;
+}
+
+body {
+  font-family: var(--font-inter);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+});
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={inter.variable}>
       <body className="bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}


### PR DESCRIPTION
## Summary
- import and configure Inter font and apply its variable class to the html root
- define --font-inter in global styles and use it for body font-family

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find package '@/lib/supabaseAdmin' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68abb0d1cae883248d284a51257f2fb2