### PR TITLE
style: refine form spacing and focus states

### DIFF
--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -45,16 +45,16 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <textarea
-        className="w-full rounded border p-2 text-sm"
+        className="w-full rounded-lg border p-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
         placeholder="Write a note..."
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
       <button
         type="submit"
-        className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground"
+        className="rounded bg-primary p-4 text-sm text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary"
       >
         Add Note
       </button>

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -48,7 +48,7 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <input
         type="file"
         accept="image/*"
@@ -56,7 +56,7 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
       />
       <button
         type="submit"
-        className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground"
+        className="rounded bg-primary p-4 text-sm text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary"
       >
         Upload Photo
       </button>


### PR DESCRIPTION
## Summary
- replace space utilities with flex gap and standardized padding
- add focus ring styling and rounded textarea edges

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '../src/lib/csv'...)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1f0e54c83248631adeb7ae2efeb