### PR TITLE
refactor: adjust gap spacing and image rounding

### DIFF
--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -26,7 +26,7 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
 
   return (
     <div>
-      <div className="mb-4 flex justify-end gap-2">
+      <div className="mb-4 flex justify-end gap-3">
         <button
           aria-label="Grid view"
           onClick={() => setView('grid')}
@@ -63,10 +63,10 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
                       <img
                         src={plant.imageUrl}
                         alt={plant.name}
-                        className="h-12 w-12 rounded object-cover"
+                        className="h-12 w-12 rounded-lg object-cover"
                       />
                     ) : (
-                      <div className="h-12 w-12 rounded bg-muted" />
+                      <div className="h-12 w-12 rounded-lg bg-muted" />
                     )}
                     <div>
                       <p className="font-medium">{plant.name}</p>

--- a/src/app/plants/new/page.tsx
+++ b/src/app/plants/new/page.tsx
@@ -47,7 +47,7 @@ export default function NewPlantPage() {
             <p className="mt-2 text-sm text-muted-foreground">{species}</p>
           )}
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-3">
           <button
             onClick={() => setPreview(false)}
             className="rounded bg-secondary px-4 py-2 text-sm text-secondary-foreground"

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -13,7 +13,7 @@ export default async function PhotoGallery({ plantId }: { plantId: string }) {
   }
 
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-2 gap-3">
       {photos.map((photo) => (
         <Image
           key={photo.id}
@@ -21,7 +21,7 @@ export default async function PhotoGallery({ plantId }: { plantId: string }) {
           alt="Plant photo"
           width={300}
           height={300}
-          className="h-32 w-full rounded object-cover"
+          className="h-32 w-full rounded-lg object-cover"
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- use `gap-3` for layouts previously using `gap-2`
- standardize image corners using `rounded-lg`

## Testing
- `pnpm test` *(fails: Cannot find module '../src/lib/csv', Cannot find module '../src/app/api/ai-care/route', Cannot find package '@/lib/supabaseAdmin', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abb371b21c832482d2e16a38925168