### PR TITLE
feat: add reusable button component

### DIFF
--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { CareEvent } from '@/types';
+import { Button } from '@/components/ui/button';
 
 interface Props {
   plantId: string;
@@ -52,12 +53,9 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
-      <button
-        type="submit"
-        className="rounded bg-primary p-4 text-sm text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-      >
+      <Button type="submit" className="p-4">
         Add Note
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { CareEvent } from '@/types';
+import { Button } from '@/components/ui/button';
 
 interface Props {
   plantId: string;
@@ -54,12 +55,9 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
         accept="image/*"
         onChange={(e) => setFile(e.target.files?.[0] ?? null)}
       />
-      <button
-        type="submit"
-        className="rounded bg-primary p-4 text-sm text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-      >
+      <Button type="submit" className="p-4">
         Upload Photo
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTheme } from 'next-themes';
+import { Button } from '@/components/ui/button';
 
 // Ensure React is available when components are rendered in tests
 (globalThis as unknown as { React?: typeof React }).React ??= React;
@@ -30,14 +31,14 @@ export default function Navigation() {
           {label}
         </Link>
       ))}
-      <button
+      <Button
         type="button"
         aria-label="Toggle theme"
         onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-        className="rounded-lg px-4 py-2 focus:ring-2 focus:ring-primary"
+        variant="ghost"
       >
         Toggle theme
-      </button>
+      </Button>
     </nav>
   );
 }

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import confetti from 'canvas-confetti';
 import { format, parseISO } from 'date-fns';
 import type { Task } from '@/types/task';
+import { Button } from '@/components/ui/button';
 
 function playChime() {
   if (typeof window === 'undefined') return;
@@ -146,18 +147,16 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
       <p className="font-medium animate-pulse-weight">{task.plantName}</p>
       <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
       <div className="mt-2 flex gap-3 sm:gap-4 md:gap-6">
-        <button
-          onClick={triggerComplete}
-          className="rounded-lg bg-primary px-4 py-2 text-xs text-primary-foreground focus:ring-2 focus:ring-primary transition-colors duration-200"
-        >
+        <Button onClick={triggerComplete} className="text-xs">
           Done
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => onSnooze(task.id)}
-          className="rounded-lg bg-secondary px-4 py-2 text-xs text-secondary-foreground focus:ring-2 focus:ring-primary transition-colors duration-200"
+          variant="secondary"
+          className="text-xs"
         >
           Snooze
-        </button>
+        </Button>
       </div>
     </li>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+function cn(...inputs: Array<string | undefined | null | false>) {
+  return twMerge(clsx(inputs));
+}
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'bg-transparent hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant }), className)}
+        ref={ref as React.Ref<HTMLButtonElement>}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };


### PR DESCRIPTION
## Summary
- build a reusable Button with `cva` variants
- use Button component across forms and navigation for consistent styling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find package '@/lib/supabaseAdmin' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68abb548a3048324a42e3f87a7baf05e