### PR TITLE
Use NextResponse.json in plants API

### DIFF
--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,6 +1,7 @@
 import { getCurrentUserId } from "@/lib/auth";
 import { supabaseAdmin } from "../../../lib/supabaseAdmin";
 import { z } from "zod";
+import { NextResponse } from "next/server";
 
 const plantSchema = z.object({
   name: z.string().min(1),
@@ -38,10 +39,10 @@ export async function POST(req: Request) {
     return new Response("Database error", { status: 500 });
   }
 
-  return new Response(JSON.stringify(inserted), { status: 200 });
+  return NextResponse.json(inserted, { status: 200 });
 }
 
-export async function GET(_req: Request) {
+export async function GET() {
   const userId = getCurrentUserId();
   const { data, error } = await supabaseAdmin
     .from("plants")
@@ -52,5 +53,5 @@ export async function GET(_req: Request) {
     return new Response("Database error", { status: 500 });
   }
 
-  return new Response(JSON.stringify(data), { status: 200 });
+  return NextResponse.json(data, { status: 200 });
 }


### PR DESCRIPTION
## Summary
- replace Response JSON construction with NextResponse.json in plants API
- drop unused request parameter in GET handler

## Testing
- `pnpm lint src/app/api/plants/route.ts`
- `pnpm test` *(fails: Cannot find module '../src/app/api/ai-care/route', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abc0381cd08324a1830ffd655fd271