### PR TITLE
fix: await header access

### DIFF
--- a/src/app/api/care-feedback/route.ts
+++ b/src/app/api/care-feedback/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: Request) {
     if (!parsed.success) {
       return new Response("Invalid data", { status: 400 });
     }
-    const userId = getCurrentUserId();
+    const userId = await getCurrentUserId();
     const { error: plantError } = await supabaseAdmin
       .from("plants")
       .select("id")

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -7,7 +7,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ) {
   const id = params.id;
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   try {
     const { data, error } = await supabaseAdmin
       .from("events")

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -24,7 +24,7 @@ const formSchema = z.object({
 
 export async function POST(req: Request) {
   const contentType = req.headers.get("content-type") || "";
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   try {
     if (contentType.includes("application/json")) {
       const body = await req.json();

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -3,7 +3,7 @@ import { supabaseAdmin } from "../../../../lib/supabaseAdmin";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data, error } = await supabaseAdmin
     .from("plants")
     .select("*")
@@ -23,7 +23,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { error } = await supabaseAdmin
     .from("plants")
     .delete()

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     return new Response("Invalid data", { status: 400 });
   }
 
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const plantData = {
     ...parsed.data,
     species: parsed.data.species?.trim() || "Unknown",
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
 }
 
 export async function GET(_req: Request) {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data, error } = await supabaseAdmin
     .from("plants")
     .select("*")

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -12,7 +12,7 @@ type SnoozeAction = { action: "snooze"; days: number; reason?: string };
 type RequestBody = CompleteAction | SnoozeAction;
 
 export async function PATCH(req: Request, { params }: Params) {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { id } = params;
 
   let body: RequestBody;

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function PlantDetailPage({
     heroUrl = photo?.url ?? null;
   }
 
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data: events } = await supabaseAdmin
     .from("events")
     .select("id, type, note, image_url, created_at")

--- a/src/components/plant/CareCoach.tsx
+++ b/src/components/plant/CareCoach.tsx
@@ -22,7 +22,7 @@ function parseInterval(value?: string | null) {
 }
 
 export default async function CareCoach({ plant }: CareCoachProps) {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data: waterEvents } = await supabaseAdmin
     .from("events")
     .select("created_at")

--- a/src/components/plant/QuickStats.tsx
+++ b/src/components/plant/QuickStats.tsx
@@ -21,7 +21,7 @@ function parseInterval(value?: string | null) {
 }
 
 export default async function QuickStats({ plant }: QuickStatsProps) {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data: waterEvents } = await supabaseAdmin
     .from("events")
     .select("created_at")

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,8 +7,9 @@ import { headers } from "next/headers";
  * populated by upstream authentication middleware. An error is thrown when the
  * header is missing to signal unauthenticated access.
  */
-export function getCurrentUserId(): string {
-  const userId = headers().get("x-user-id");
+export async function getCurrentUserId(): Promise<string> {
+  const headersList = await headers();
+  const userId = headersList.get("x-user-id");
   if (!userId) {
     throw new Error("Unauthorized");
   }

--- a/tests/care-feedback.api.test.ts
+++ b/tests/care-feedback.api.test.ts
@@ -4,7 +4,7 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
 
 vi.mock("@/lib/auth", () => ({
-  getCurrentUserId: () => "user-123",
+  getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
 const insertMock = vi.fn().mockResolvedValue({ error: null });

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -4,7 +4,7 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
 
 vi.mock("@/lib/auth", () => ({
-  getCurrentUserId: () => "user-123",
+  getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
 let destroyedId: string | null = null;

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -5,7 +5,7 @@ import { renderToString } from "react-dom/server";
 (globalThis as unknown as { React: typeof React }).React = React;
 
 vi.mock("@/lib/auth", () => ({
-  getCurrentUserId: () => "user-123",
+  getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
 vi.mock("@/components/AddNoteForm", () => ({ default: () => null }));

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -4,7 +4,7 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
 
 vi.mock("@/lib/auth", () => ({
-  getCurrentUserId: () => "user-123",
+  getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
 let inserted: Record<string, unknown> | null;

--- a/tests/plants.page.test.tsx
+++ b/tests/plants.page.test.tsx
@@ -8,7 +8,7 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
 
 vi.mock('@/lib/auth', () => ({
-  getCurrentUserId: () => 'user-123',
+  getCurrentUserId: () => Promise.resolve('user-123'),
 }));
 
 vi.mock('next/link', () => ({

--- a/tests/tasks.api.test.ts
+++ b/tests/tasks.api.test.ts
@@ -9,7 +9,7 @@ let plantCarePlan: Record<string, unknown> | null = null;
 let eventInserts: Record<string, unknown>[] = [];
 
 vi.mock("@/lib/auth", () => ({
-  getCurrentUserId: () => "user-123",
+  getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
 vi.mock("@/lib/analytics", () => ({


### PR DESCRIPTION
## Summary
- make `getCurrentUserId` async and await header access
- await `getCurrentUserId` across routes and components
- adjust tests for async `getCurrentUserId`

## Testing
- `npm test` *(fails: Cannot find package '@/components/ui/button' imported)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abc0a708388324961b2bc44fa85767