### PR TITLE
feat(api): validate ai-care request

### DIFF
--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,7 +1,23 @@
+import { z } from "zod";
+import { NextResponse } from "next/server";
+
+const bodySchema = z.object({
+  potSize: z.number(),
+  potUnit: z.enum(["in", "cm"]),
+  species: z.string().optional(),
+});
+
 export async function POST(req: Request) {
-  const { potSize, potUnit, species } = await req.json();
-  const size = potUnit === 'in' ? Math.round(potSize / 2.54) : potSize;
+  const json = await req.json();
+  const parsed = bodySchema.safeParse(json);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data" }, { status: 400 });
+  }
+
+  const { potSize, potUnit } = parsed.data;
+  const size = potUnit === "in" ? Math.round(potSize / 2.54) : potSize;
   const rationale = `${size}${potUnit}`;
-  const confidence = 'medium';
-  return Response.json({ rationale, confidence });
+  const confidence = "medium";
+  return NextResponse.json({ rationale, confidence });
 }

--- a/tests/ai-care.api.test.ts
+++ b/tests/ai-care.api.test.ts
@@ -36,4 +36,16 @@ describe("POST /api/ai-care", () => {
     const json = await res.json();
     expect(json.confidence).toBe("medium");
   });
+
+  it("returns 400 for invalid data", async () => {
+    const { POST } = await import("../src/app/api/ai-care/route");
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ potSize: 10, potUnit: "mm" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid data");
+  });
 });


### PR DESCRIPTION
## Summary
- validate POST /api/ai-care requests with zod
- handle invalid data with 400 responses
- test ai-care endpoint for valid, invalid units

## Testing
- `pnpm lint` *(fails: Unexpected any in src/lib/csv.ts)*
- `pnpm test` *(fails: tests/events.api.test.ts & tests/plant.page.test.ts)*
- `pnpm test tests/ai-care.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68abc49011c48324b50cedddda7dcb59