### PR TITLE
refactor: tighten CSV helper types

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,9 +1,9 @@
-export function toCsv(rows: Record<string, any>[]): string {
+export function toCsv<T extends Record<string, unknown>>(rows: T[]): string {
   const headers = Array.from(new Set(rows.flatMap(r => Object.keys(r))));
-  const escape = (v: any) =>
+  const escape = (v: unknown): string =>
     v === undefined || v === null
       ? ''
       : `"${String(v).replace(/"/g, '""')}"`;
-  const lines = rows.map(r => headers.map(h => escape(r[h])).join(","));
+  const lines = rows.map(r => headers.map(h => escape(r[h as keyof T])).join(","));
   return `${headers.join(",")}\n${lines.join("\n")}`;
 }


### PR DESCRIPTION
## Summary
- strengthen CSV conversion utility with generic `toCsv<T extends Record<string, unknown>>`
- type `escape` helper as `(v: unknown) => string`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test timed out, missing Supabase configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abc4ed2a008324a54467945bb3e77c