### PR TITLE
refactor: use NextResponse in API routes

### DIFF
--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,7 +1,9 @@
+import { NextResponse } from "next/server";
+
 export async function POST(req: Request) {
   const { potSize, potUnit, species } = await req.json();
   const size = potUnit === 'in' ? Math.round(potSize / 2.54) : potSize;
   const rationale = `${size}${potUnit}`;
   const confidence = 'medium';
-  return Response.json({ rationale, confidence });
+  return NextResponse.json({ rationale, confidence });
 }

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,38 +1,53 @@
 import { getCurrentUserId } from "@/lib/auth";
 import { supabaseAdmin } from "../../../../lib/supabaseAdmin";
+import { NextResponse } from "next/server";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const userId = getCurrentUserId();
-  const { data, error } = await supabaseAdmin
-    .from("plants")
-    .select("*")
-    .eq("id", id)
-    .eq("user_id", userId);
+  try {
+    const { id } = await params;
+    const userId = getCurrentUserId();
+    const { data, error } = await supabaseAdmin
+      .from("plants")
+      .select("*")
+      .eq("id", id)
+      .eq("user_id", userId);
 
-  if (error) {
-    return new Response("Database error", { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    if (!data || data.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(data[0], { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
-
-  if (!data || data.length === 0) {
-    return new Response("Not found", { status: 404 });
-  }
-
-  return new Response(JSON.stringify(data[0]), { status: 200 });
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const userId = getCurrentUserId();
-  const { error } = await supabaseAdmin
-    .from("plants")
-    .delete()
-    .eq("id", id)
-    .eq("user_id", userId);
+  try {
+    const { id } = await params;
+    const userId = getCurrentUserId();
+    const { error } = await supabaseAdmin
+      .from("plants")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", userId);
 
-  if (error) {
-    return new Response("Database error", { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    return NextResponse.json({}, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
-
-  return new Response(null, { status: 200 });
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { getCurrentUserId } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { logEvent } from "@/lib/analytics";
 import { addDays, formatISO, parseISO } from "date-fns";
+import { NextResponse } from "next/server";
 
 interface Params {
   params: { id: string };
@@ -12,101 +13,108 @@ type SnoozeAction = { action: "snooze"; days: number; reason?: string };
 type RequestBody = CompleteAction | SnoozeAction;
 
 export async function PATCH(req: Request, { params }: Params) {
-  const userId = getCurrentUserId();
-  const { id } = params;
-
-  let body: RequestBody;
   try {
-    body = (await req.json()) as RequestBody;
-  } catch {
-    return new Response("Invalid JSON", { status: 400 });
-  }
+    const userId = getCurrentUserId();
+    const { id } = params;
 
-  if (body.action === "complete") {
-    const { data: task, error: taskError } = await supabaseAdmin
-      .from("tasks")
-      .select("plant_id, type")
-      .eq("id", id)
-      .eq("user_id", userId)
-      .single();
-    if (taskError || !task) {
-      return new Response("Task not found", { status: 404 });
+    let body: RequestBody;
+    try {
+      body = (await req.json()) as RequestBody;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { error } = await supabaseAdmin
-      .from("tasks")
-      .update({ completed_at: new Date().toISOString() })
-      .eq("id", id)
-      .eq("user_id", userId);
-    if (error) {
-      return new Response("Database error", { status: 500 });
-    }
+    if (body.action === "complete") {
+      const { data: task, error: taskError } = await supabaseAdmin
+        .from("tasks")
+        .select("plant_id, type")
+        .eq("id", id)
+        .eq("user_id", userId)
+        .single();
+      if (taskError || !task) {
+        return NextResponse.json({ error: "Task not found" }, { status: 404 });
+      }
 
-    const { error: eventError } = await supabaseAdmin.from("events").insert({
-      plant_id: task.plant_id as string,
-      user_id: userId,
-      type: task.type as string,
-    });
-    if (eventError) {
-      return new Response("Database error", { status: 500 });
-    }
-
-    await logEvent("task_completed", { task_id: id });
-    return new Response(null, { status: 200 });
-  }
-
-  if (body.action === "snooze") {
-    const days = typeof body.days === "number" ? body.days : 0;
-    const reason = body.reason as string | undefined;
-
-    const { data: task, error: taskError } = await supabaseAdmin
-      .from("tasks")
-      .select("due_date, plant_id")
-      .eq("id", id)
-      .eq("user_id", userId)
-      .single();
-    if (taskError || !task) {
-      return new Response("Task not found", { status: 404 });
-    }
-
-    const due = parseISO(task.due_date as string);
-    const newDue = formatISO(addDays(due, days), { representation: "date" });
-
-    const { error: updateError } = await supabaseAdmin
-      .from("tasks")
-      .update({ due_date: newDue, snooze_reason: reason })
-      .eq("id", id)
-      .eq("user_id", userId);
-    if (updateError) {
-      return new Response("Database error", { status: 500 });
-    }
-
-    const { data: plant } = await supabaseAdmin
-      .from("plants")
-      .select("care_plan")
-      .eq("id", task.plant_id as string)
-      .eq("user_id", userId)
-      .single();
-
-    const current = plant?.care_plan as { waterEvery?: string } | null;
-    if (current?.waterEvery) {
-      const match = current.waterEvery.match(/(\d+)/);
-      const interval = match ? parseInt(match[1], 10) : 0;
-      const updatedPlan = {
-        ...current,
-        waterEvery: `${interval + days} days`,
-      };
-      await supabaseAdmin
-        .from("plants")
-        .update({ care_plan: updatedPlan })
-        .eq("id", task.plant_id as string)
+      const { error } = await supabaseAdmin
+        .from("tasks")
+        .update({ completed_at: new Date().toISOString() })
+        .eq("id", id)
         .eq("user_id", userId);
+      if (error) {
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      const { error: eventError } = await supabaseAdmin.from("events").insert({
+        plant_id: task.plant_id as string,
+        user_id: userId,
+        type: task.type as string,
+      });
+      if (eventError) {
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      await logEvent("task_completed", { task_id: id });
+      return NextResponse.json({}, { status: 200 });
     }
 
-    return new Response(null, { status: 200 });
-  }
+    if (body.action === "snooze") {
+      const days = typeof body.days === "number" ? body.days : 0;
+      const reason = body.reason as string | undefined;
 
-  return new Response("Invalid action", { status: 400 });
+      const { data: task, error: taskError } = await supabaseAdmin
+        .from("tasks")
+        .select("due_date, plant_id")
+        .eq("id", id)
+        .eq("user_id", userId)
+        .single();
+      if (taskError || !task) {
+        return NextResponse.json({ error: "Task not found" }, { status: 404 });
+      }
+
+      const due = parseISO(task.due_date as string);
+      const newDue = formatISO(addDays(due, days), { representation: "date" });
+
+      const { error: updateError } = await supabaseAdmin
+        .from("tasks")
+        .update({ due_date: newDue, snooze_reason: reason })
+        .eq("id", id)
+        .eq("user_id", userId);
+      if (updateError) {
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      const { data: plant } = await supabaseAdmin
+        .from("plants")
+        .select("care_plan")
+        .eq("id", task.plant_id as string)
+        .eq("user_id", userId)
+        .single();
+
+      const current = plant?.care_plan as { waterEvery?: string } | null;
+      if (current?.waterEvery) {
+        const match = current.waterEvery.match(/(\d+)/);
+        const interval = match ? parseInt(match[1], 10) : 0;
+        const updatedPlan = {
+          ...current,
+          waterEvery: `${interval + days} days`,
+        };
+        await supabaseAdmin
+          .from("plants")
+          .update({ care_plan: updatedPlan })
+          .eq("id", task.plant_id as string)
+          .eq("user_id", userId);
+      }
+
+      return NextResponse.json({}, { status: 200 });
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
 }
 
 export const runtime = "edge";


### PR DESCRIPTION
## Summary
- replace Response usages in API routes with NextResponse.json
- move `getCurrentUserId` inside try blocks and handle Unauthorized errors
- standardize success/error JSON responses

## Testing
- `pnpm lint` *(fails: Unexpected any in src/lib/csv.ts)*
- `pnpm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68abc47e9d48832499c894121680b6cd