### PR TITLE
feat: improve error handling and radius tokens

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -90,7 +90,7 @@ colors: {
 ### 2.3 Spacing, Radius, Shadow, Motion
 
 * **Spacing**: `p-4/6/8`, `gap-3/4/6`.
-* **Corners**: `rounded-xl` for cards, `rounded-lg` for inputs.
+* **Corners**: `rounded-xl` for cards and inputs.
 * **Depth**: `shadow-sm` resting, `shadow-md` on hover.
 * **Motion durations**: 120–280ms based on element type.
 * **Easings**: emphasized out, standard out, smooth in‑out (defined in globals).

--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -30,14 +30,14 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
         <button
           aria-label="Grid view"
           onClick={() => setView('grid')}
-          className={`rounded-lg px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'grid' ? 'bg-muted' : ''}`}
+          className={`rounded-xl px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'grid' ? 'bg-muted' : ''}`}
         >
           Grid
         </button>
         <button
           aria-label="List view"
           onClick={() => setView('list')}
-          className={`rounded-lg px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'list' ? 'bg-muted' : ''}`}
+          className={`rounded-xl px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'list' ? 'bg-muted' : ''}`}
         >
           List
         </button>
@@ -63,10 +63,10 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
                       <img
                         src={plant.imageUrl}
                         alt={plant.name}
-                        className="h-12 w-12 rounded-lg object-cover"
+                        className="h-12 w-12 rounded-xl object-cover"
                       />
                     ) : (
-                      <div className="h-12 w-12 rounded-lg bg-muted" />
+                      <div className="h-12 w-12 rounded-xl bg-muted" />
                     )}
                     <div>
                       <p className="font-medium">{plant.name}</p>

--- a/src/app/plants/new/page.tsx
+++ b/src/app/plants/new/page.tsx
@@ -107,7 +107,7 @@ export default function NewPlantPage() {
             required
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="h-11 w-full rounded-lg border px-3 text-sm transition-colors focus:border-primary focus:outline-none"
+            className="h-11 w-full rounded-xl border px-3 text-sm transition-colors focus:border-primary focus:outline-none"
           />
         </div>
         <SpeciesAutosuggest value={species} onSelect={setSpecies} />

--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
   const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -27,6 +28,7 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
     };
     onAdd(optimistic);
     setNote('');
+    setError(null);
     try {
       const res = await fetch('/api/events', {
         method: 'POST',
@@ -39,20 +41,28 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
         if (real) {
           onReplace(tempId, real);
         }
+      } else {
+        setError('Failed to add note');
       }
     } catch (err) {
       console.error('Failed to add note', err);
+      setError('Failed to add note');
     }
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <textarea
-        className="w-full rounded-lg border p-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        className="w-full rounded-xl border p-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
         placeholder="Write a note..."
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
+      {error && (
+        <p className="text-sm text-destructive" aria-live="polite">
+          {error}
+        </p>
+      )}
       <Button type="submit" className="p-4">
         Add Note
       </Button>

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -30,6 +31,7 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
     formData.append('type', 'photo');
     formData.append('photo', file);
     setFile(null);
+    setError(null);
     (e.target as HTMLFormElement).reset();
     try {
       const res = await fetch('/api/events', {
@@ -42,9 +44,12 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
         if (real) {
           onReplace(tempId, real);
         }
+      } else {
+        setError('Failed to upload photo');
       }
     } catch (err) {
       console.error('Failed to upload photo', err);
+      setError('Failed to upload photo');
     }
   }
 
@@ -55,6 +60,11 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
         accept="image/*"
         onChange={(e) => setFile(e.target.files?.[0] ?? null)}
       />
+      {error && (
+        <p className="text-sm text-destructive" aria-live="polite">
+          {error}
+        </p>
+      )}
       <Button type="submit" className="p-4">
         Upload Photo
       </Button>

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -21,7 +21,7 @@ export default async function PhotoGallery({ plantId }: { plantId: string }) {
           alt="Plant photo"
           width={300}
           height={300}
-          className="h-32 w-full rounded-lg object-cover"
+          className="h-32 w-full rounded-xl object-cover"
         />
       ))}
     </div>

--- a/src/components/SpeciesAutosuggest.tsx
+++ b/src/components/SpeciesAutosuggest.tsx
@@ -18,6 +18,7 @@ export default function SpeciesAutosuggest({
   const [query, setQuery] = React.useState(value);
   const [results, setResults] = React.useState<string[]>([]);
   const [open, setOpen] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     setQuery(value);
@@ -26,6 +27,7 @@ export default function SpeciesAutosuggest({
   React.useEffect(() => {
     if (!query) {
       setResults([]);
+      setError(null);
       return;
     }
 
@@ -40,10 +42,14 @@ export default function SpeciesAutosuggest({
               )
             : [];
           setResults(names);
+          setError(null);
           setOpen(true);
+        } else {
+          setError('Failed to load species');
         }
       } catch (err) {
         console.error('Species search failed', err);
+        setError('Failed to load species');
       }
     }, 300);
 
@@ -73,6 +79,11 @@ export default function SpeciesAutosuggest({
         placeholder="Search species..."
         className="h-11 w-full rounded-xl border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
+      {error && (
+        <p className="mt-1 text-sm text-destructive" aria-live="polite">
+          {error}
+        </p>
+      )}
       {open && results.length > 0 && (
         <ul className="absolute z-10 mt-1 w-full rounded-md border bg-background text-foreground shadow-md" role="listbox">
           {results.map((r) => (

--- a/src/components/plant/PlantCard.tsx
+++ b/src/components/plant/PlantCard.tsx
@@ -12,7 +12,7 @@ export default function PlantCard({ plant }: { plant: Plant }) {
   return (
     <Link
       href={`/plants/${plant.id}`}
-      className="block overflow-hidden rounded-lg border"
+      className="block overflow-hidden rounded-xl border"
     >
       {plant.imageUrl ? (
         <Image

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,7 +9,7 @@ function cn(...inputs: Array<string | undefined | null | false>) {
 }
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,9 +1,9 @@
-export function toCsv(rows: Record<string, any>[]): string {
-  const headers = Array.from(new Set(rows.flatMap(r => Object.keys(r))));
-  const escape = (v: any) =>
+export function toCsv(rows: Array<Record<string, unknown>>): string {
+  const headers = Array.from(new Set(rows.flatMap((r) => Object.keys(r))));
+  const escape = (v: unknown) =>
     v === undefined || v === null
       ? ''
       : `"${String(v).replace(/"/g, '""')}"`;
-  const lines = rows.map(r => headers.map(h => escape(r[h])).join(","));
-  return `${headers.join(",")}\n${lines.join("\n")}`;
+  const lines = rows.map((r) => headers.map((h) => escape(r[h])).join(','));
+  return `${headers.join(',')}\n${lines.join('\n')}`;
 }


### PR DESCRIPTION
## Summary
- replace `rounded-lg` with `rounded-xl` across UI and docs
- add inline error handling for note, photo, and species forms
- remove `any` usage in CSV utility

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test timed out, environment variables missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abc4efd6b8832493173868fb08883f