### PR TITLE
fix: handle Supabase errors in AI care

### DIFF
--- a/src/lib/aiCare.ts
+++ b/src/lib/aiCare.ts
@@ -5,13 +5,18 @@ export async function getAiCareSuggestions(plantId: string) {
   const userId = getCurrentUserId();
   const today = new Date().toISOString().slice(0, 10);
 
-  const { data: tasks } = await supabaseAdmin
+  const { data: tasks, error } = await supabaseAdmin
     .from("tasks")
     .select("type, due_date")
     .eq("user_id", userId)
     .eq("plant_id", plantId)
     .is("completed_at", null)
     .lte("due_date", today);
+
+  if (error) {
+    console.error("Error fetching tasks:", error);
+    throw new Error("Failed to fetch tasks");
+  }
 
   const suggestions: string[] = [];
   tasks?.forEach((t) => {

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -174,8 +174,10 @@ describe("POST /api/events", () => {
     form.set("type", "photo");
     const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
     form.set("photo", file);
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(updatedImageUrl).toBe("https://example.com/uploaded.jpg");

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -44,8 +44,10 @@ describe("POST /api/plants", () => {
     const form = new FormData();
     form.set("name", "Fern");
     form.set("species", "Pteridophyta");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
   });
@@ -54,8 +56,10 @@ describe("POST /api/plants", () => {
     const { POST } = await import("../src/app/api/plants/route");
     const form = new FormData();
     form.set("species", "Pteridophyta");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
@@ -64,8 +68,10 @@ describe("POST /api/plants", () => {
     const { POST } = await import("../src/app/api/plants/route");
     const form = new FormData();
     form.set("name", "Fern");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(inserted.species).toBe("Unknown");
@@ -77,8 +83,10 @@ describe("POST /api/plants", () => {
     form.set("name", "Fern");
     form.set("species", "Pteridophyta");
     form.set("latitude", "not-a-number");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- handle Supabase `tasks` query errors in AI care suggestions
- replace `any` casts in tests with typed requests for lint compliance

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd22f44ac83248370d949a9af56aa