### PR TITLE
fix: await user id in dashboard page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 
 export default async function DashboardPage() {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const { data: tasks } = await supabaseAdmin
     .from("tasks")
     .select("id, completed_at")

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -175,7 +175,10 @@ describe("POST /api/events", () => {
     const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
     form.set("photo", file);
     const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const reqWithForm = req as unknown as {
+      formData: () => Promise<FormData>;
+    };
+    reqWithForm.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(updatedImageUrl).toBe("https://example.com/uploaded.jpg");

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -45,7 +45,10 @@ describe("POST /api/plants", () => {
     form.set("name", "Fern");
     form.set("species", "Pteridophyta");
     const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const reqWithForm = req as unknown as {
+      formData: () => Promise<FormData>;
+    };
+    reqWithForm.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
   });
@@ -55,7 +58,10 @@ describe("POST /api/plants", () => {
     const form = new FormData();
     form.set("species", "Pteridophyta");
     const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const reqWithForm = req as unknown as {
+      formData: () => Promise<FormData>;
+    };
+    reqWithForm.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
@@ -65,7 +71,10 @@ describe("POST /api/plants", () => {
     const form = new FormData();
     form.set("name", "Fern");
     const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const reqWithForm = req as unknown as {
+      formData: () => Promise<FormData>;
+    };
+    reqWithForm.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(inserted.species).toBe("Unknown");
@@ -78,7 +87,10 @@ describe("POST /api/plants", () => {
     form.set("species", "Pteridophyta");
     form.set("latitude", "not-a-number");
     const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const reqWithForm = req as unknown as {
+      formData: () => Promise<FormData>;
+    };
+    reqWithForm.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- await user ID retrieval in dashboard page before running Supabase queries
- replace `any` casts with typed `reqWithForm` in API tests to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd22ca4e48324b3eb6d0719525cf9