### PR TITLE
fix: await user id for ai care suggestions

### DIFF
--- a/src/lib/aiCare.ts
+++ b/src/lib/aiCare.ts
@@ -2,7 +2,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
 export async function getAiCareSuggestions(plantId: string) {
-  const userId = getCurrentUserId();
+  const userId = await getCurrentUserId();
   const today = new Date().toISOString().slice(0, 10);
 
   const { data: tasks } = await supabaseAdmin

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -174,8 +174,10 @@ describe("POST /api/events", () => {
     form.set("type", "photo");
     const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
     form.set("photo", file);
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as unknown as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(updatedImageUrl).toBe("https://example.com/uploaded.jpg");

--- a/tests/plants.api.test.ts
+++ b/tests/plants.api.test.ts
@@ -44,8 +44,10 @@ describe("POST /api/plants", () => {
     const form = new FormData();
     form.set("name", "Fern");
     form.set("species", "Pteridophyta");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as unknown as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
   });
@@ -54,8 +56,10 @@ describe("POST /api/plants", () => {
     const { POST } = await import("../src/app/api/plants/route");
     const form = new FormData();
     form.set("species", "Pteridophyta");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as unknown as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });
@@ -64,8 +68,10 @@ describe("POST /api/plants", () => {
     const { POST } = await import("../src/app/api/plants/route");
     const form = new FormData();
     form.set("name", "Fern");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as unknown as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(inserted.species).toBe("Unknown");
@@ -77,8 +83,10 @@ describe("POST /api/plants", () => {
     form.set("name", "Fern");
     form.set("species", "Pteridophyta");
     form.set("latitude", "not-a-number");
-    const req = new Request("http://localhost", { method: "POST" });
-    (req as any).formData = () => Promise.resolve(form);
+    const req = new Request("http://localhost", { method: "POST" }) as unknown as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
     const res = await POST(req);
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- await current user ID when fetching AI care suggestions
- replace `any` casts in tests with typed request mocks to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd228392483248aed5a66c1fd9067