### PR TITLE
Restore shadcn styling utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,57 +2,57 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: 0 0% 100%;
-  --foreground: 221 39% 11%;
-  --card: 0 0% 100%;
-  --card-foreground: 221 39% 11%;
-  --primary: 166 27% 43%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 164 42% 88%;
-  --secondary-foreground: 173 30% 17%;
-  --accent: 164 42% 88%;
-  --accent-foreground: 173 30% 17%;
-  --muted: 210 20% 96%;
-  --muted-foreground: 220 9% 46%;
-  --border: 220 13% 91%;
-  --ring: 166 27% 43%;
-  --destructive: 0 72% 50%;
-  --destructive-foreground: 0 0% 98%;
-  --success: 142 72% 29%;
-  --success-foreground: 0 0% 98%;
-  --warning: 38 92% 50%;
-  --warning-foreground: 0 0% 98%;
-  --info: 201 96% 32%;
-  --info-foreground: 0 0% 98%;
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 221 39% 11%;
+    --card: 0 0% 100%;
+    --card-foreground: 221 39% 11%;
+    --primary: 166 27% 43%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 164 42% 88%;
+    --secondary-foreground: 173 30% 17%;
+    --accent: 164 42% 88%;
+    --accent-foreground: 173 30% 17%;
+    --muted: 210 20% 96%;
+    --muted-foreground: 220 9% 46%;
+    --border: 220 13% 91%;
+    --ring: 166 27% 43%;
+    --destructive: 0 72% 50%;
+    --destructive-foreground: 0 0% 98%;
+    --success: 142 72% 29%;
+    --success-foreground: 0 0% 98%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 98%;
+    --info: 201 96% 32%;
+    --info-foreground: 0 0% 98%;
+    --font-inter: 'Inter', sans-serif;
+  }
 
-  --font-inter: 'Inter', sans-serif;
-
-}
-
-.dark {
-  --background: 220 49% 8%;
-  --foreground: 220 13% 91%;
-  --card: 220 46% 10%;
-  --card-foreground: 220 13% 91%;
-  --primary: 166 30% 51%;
-  --primary-foreground: 220 49% 8%;
-  --secondary: 170 42% 16%;
-  --secondary-foreground: 163 39% 93%;
-  --accent: 170 42% 16%;
-  --accent-foreground: 163 39% 93%;
-  --muted: 218 41% 11%;
-  --muted-foreground: 215 20% 65%;
-  --border: 215 28% 17%;
-  --ring: 166 30% 51%;
-  --destructive: 0 70% 58%;
-  --destructive-foreground: 0 0% 98%;
-  --success: 142 70% 42%;
-  --success-foreground: 220 49% 8%;
-  --warning: 38 92% 60%;
-  --warning-foreground: 220 49% 8%;
-  --info: 201 96% 40%;
-  --info-foreground: 220 49% 8%;
+  .dark {
+    --background: 220 49% 8%;
+    --foreground: 220 13% 91%;
+    --card: 220 46% 10%;
+    --card-foreground: 220 13% 91%;
+    --primary: 166 30% 51%;
+    --primary-foreground: 220 49% 8%;
+    --secondary: 170 42% 16%;
+    --secondary-foreground: 163 39% 93%;
+    --accent: 170 42% 16%;
+    --accent-foreground: 163 39% 93%;
+    --muted: 218 41% 11%;
+    --muted-foreground: 215 20% 65%;
+    --border: 215 28% 17%;
+    --ring: 166 30% 51%;
+    --destructive: 0 70% 58%;
+    --destructive-foreground: 0 0% 98%;
+    --success: 142 70% 42%;
+    --success-foreground: 220 49% 8%;
+    --warning: 38 92% 60%;
+    --warning-foreground: 220 49% 8%;
+    --info: 201 96% 40%;
+    --info-foreground: 220 49% 8%;
+  }
 }
 
 body {

--- a/src/app/plants/new/page.tsx
+++ b/src/app/plants/new/page.tsx
@@ -1,11 +1,21 @@
-import AddPlantForm from '@/components/plant/AddPlantForm';
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
 
-export default function NewPlantPage() {
-
+export default function Page() {
   return (
-    <div className="max-w-md p-4 md:p-6 mx-auto">
-      <AddPlantForm />
+    <div className="max-w-md mx-auto space-y-4 mt-8">
+      <div className="space-y-2">
+        <Label htmlFor="name">Nickname</Label>
+        <Input id="name" placeholder="Kay" />
+      </div>
 
+      <div className="space-y-2">
+        <Label htmlFor="species">Species</Label>
+        <Input id="species" placeholder="Search species..." />
+      </div>
+
+      <Button className="w-full">Create Plant</Button>
     </div>
-  );
+  )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,12 +1,7 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-primary disabled:pointer-events-none disabled:opacity-50',
@@ -23,26 +18,26 @@ const buttonVariants = cva(
       variant: 'default',
     },
   },
-);
+)
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  asChild?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
+    const Comp = asChild ? Slot : 'button'
     return (
       <Comp
         className={cn(buttonVariants({ variant }), className)}
         ref={ref as React.Ref<HTMLButtonElement>}
         {...props}
       />
-    );
+    )
   },
-);
-Button.displayName = 'Button';
+)
+Button.displayName = 'Button'
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,15 +1,10 @@
-'use client';
-import * as React from 'react';
-import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+'use client'
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
 
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
-
-const DropdownMenu = DropdownMenuPrimitive.Root;
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -23,8 +18,8 @@ const DropdownMenuContent = React.forwardRef<
     )}
     {...props}
   />
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
@@ -38,7 +33,7 @@ const DropdownMenuItem = React.forwardRef<
     )}
     {...props}
   />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem };
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,12 +1,7 @@
-import * as React from 'react';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
-
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => {
   return (
@@ -18,8 +13,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
       )}
       {...props}
     />
-  );
-});
-Input.displayName = 'Input';
+  )
+})
+Input.displayName = 'Input'
 
-export { Input };
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,12 +1,7 @@
-import * as React from 'react';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
-
-export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
   <label
@@ -14,7 +9,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...pr
     className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
     {...props}
   />
-));
-Label.displayName = 'Label';
+))
+Label.displayName = 'Label'
 
-export { Label };
+export { Label }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,14 +1,9 @@
-'use client';
-import * as React from 'react';
-import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+'use client'
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { cn } from '@/lib/utils'
 
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
-
-const Tabs = TabsPrimitive.Root;
+const Tabs = TabsPrimitive.Root
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -22,8 +17,8 @@ const TabsList = React.forwardRef<
     )}
     {...props}
   />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+))
+TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -37,8 +32,8 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -52,7 +47,7 @@ const TabsContent = React.forwardRef<
     )}
     {...props}
   />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,16 +1,11 @@
-'use client';
-import * as React from 'react';
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+'use client'
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import { cn } from '@/lib/utils'
 
-function cn(...inputs: Array<string | undefined | null | false>) {
-  return twMerge(clsx(inputs));
-}
-
-const TooltipProvider = TooltipPrimitive.Provider;
-const Tooltip = TooltipPrimitive.Root;
-const TooltipTrigger = TooltipPrimitive.Trigger;
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
@@ -25,7 +20,7 @@ const TooltipContent = React.forwardRef<
     )}
     {...props}
   />
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: string[]) {
+  return inputs.filter(Boolean).join(' ')
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,14 +1,10 @@
-import type { Config } from "tailwindcss";
-import animate from "tailwindcss-animate";
+import { type Config } from "tailwindcss"
 
-export default {
+const config: Config = {
   darkMode: "class",
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
     extend: {
-      fontFamily: {
-        inter: ["var(--font-inter)", "sans-serif"],
-      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
@@ -53,9 +49,12 @@ export default {
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        xl: "calc(var(--radius) + 4px)",
-        "2xl": "calc(var(--radius) + 8px)",
+        lg: "0.5rem",
+        md: "0.375rem",
+        sm: "0.25rem",
+      },
+      fontFamily: {
+        inter: ["var(--font-inter)", "sans-serif"],
       },
       boxShadow: {
         card: "0 4px 6px -1px rgba(0,0,0,0.05)",
@@ -71,5 +70,8 @@ export default {
       },
     },
   },
-  plugins: [animate],
-} satisfies Config;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  plugins: [require("tailwindcss-animate")],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- add simple `cn` helper and refactor UI components to use it
- wrap CSS variables in `@layer base` and refresh tailwind config
- replace plant creation page with basic shadcn form

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd6265c4c83248269829eefdc295f