### PR TITLE
feat: add empty plant state and theme auto-detect

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -28,11 +28,11 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 0. First Run & Setup
-- [ ] Detect user theme and load fonts
+- [x] Detect user theme and load fonts
 - [ ] Load user profile and feature flags
 - [ ] Request location permission and cache city/lat/lon
 - [ ] Fetch and cache weather data (30–60 min)
-- [ ] Render empty state with CTA to add first plant
+- [x] Render empty state with CTA to add first plant
 
 **Empty State Example:**
 ```tsx

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning className={inter.variable}>
       <body className="bg-background text-foreground">
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
           <Toaster richColors />
         </ThemeProvider>

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import PlantList from './PlantList';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import EmptyPlantState from '@/components/EmptyPlantState';
 
 export default async function PlantsPage() {
   const { data: plants, error } = await supabaseAdmin
@@ -23,14 +23,7 @@ export default async function PlantsPage() {
     })) ?? [];
 
   if (mappedPlants.length === 0) {
-    return (
-      <div className="p-4 md:p-6 text-center max-w-md mx-auto">
-        <p className="mb-4">You haven&apos;t added any plants yet.</p>
-        <Link href="/plants/new" className="text-primary underline">
-          Add your first plant
-        </Link>
-      </div>
-    );
+    return <EmptyPlantState />;
   }
 
   return (

--- a/src/components/EmptyPlantState.tsx
+++ b/src/components/EmptyPlantState.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function EmptyPlantState() {
+  return (
+    <div className="text-center py-20 space-y-4">
+      <p className="text-lg font-medium">No plants yet 🌱</p>
+      <p className="text-sm text-muted-foreground">Add your first plant to get started.</p>
+      <Button asChild className="px-4 py-2 text-sm font-medium">
+        <Link href="/plants/new">Add a Plant</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as CareTimeline } from './CareTimeline';
 export { default as EventsSection } from './EventsSection';
 export { default as TaskList } from './TaskList';
 export { default as Navigation } from './Navigation';
+export { default as EmptyPlantState } from './EmptyPlantState';


### PR DESCRIPTION
## Summary
- auto-detect user theme via next-themes
- show empty state CTA when no plants exist
- mark corresponding implementation tasks as complete

## Testing
- `pnpm lint` (fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type, @next/next/no-img-element, @typescript-eslint/no-unused-vars, import/no-anonymous-default-export)
- `pnpm test` (fails: POST /api/plants tests expect status codes and GET handler missing)


------
https://chatgpt.com/codex/tasks/task_e_68abe113294c83249bb0f1221a5dfd00