### PR TITLE
feat: add dashboard stats api and page

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+function supabaseServer() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  if (!url || !key) throw new Error("Missing SUPABASE env vars")
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+export async function GET() {
+  try {
+    const supabase = supabaseServer()
+
+    // Weekly completion (approx): last 7d events count vs plants*expected(1)
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+    const { data: events, error: evErr } = await supabase
+      .from("events")
+      .select("id, created_at, plant_id, type")
+      .gte("created_at", since)
+
+    if (evErr) throw evErr
+
+    const { data: plants, error: pErr } = await supabase.from("plants").select("id")
+
+    if (pErr) throw pErr
+
+    const totalExpected = (plants?.length || 0) * 1 // naive: 1 action per plant per week
+    const totalDone = events?.length || 0
+    const completion =
+      totalExpected === 0
+        ? 0
+        : Math.min(100, Math.round((totalDone / totalExpected) * 100))
+
+    // Overdue trend is placeholder (requires schedules); return last7 days histogram of events
+    const hist = Array.from({ length: 7 }, (_, i) => {
+      const dayStart = new Date()
+      dayStart.setHours(0, 0, 0, 0)
+      dayStart.setDate(dayStart.getDate() - i)
+      const dayEnd = new Date(dayStart)
+      dayEnd.setDate(dayStart.getDate() + 1)
+      const count = (events || []).filter(e => {
+        const t = new Date(e.created_at).getTime()
+        return t >= dayStart.getTime() && t < dayEnd.getTime()
+      }).length
+      return { day: dayStart.toISOString().slice(0, 10), count }
+    }).reverse()
+
+    return NextResponse.json(
+      { completion, totalDone, totalExpected, hist, plants: plants?.length || 0 },
+      { status: 200 }
+    )
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Server error"
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/dashboard` endpoint for weekly completion and activity histogram
- build `/dashboard` UI with cards and activity chart

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@testing-library/jest-dom" from "test/setup.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68abec2939488324b003f1b4db467796