### PR TITLE
feat: add rooms and events timeline

### DIFF
--- a/src/components/plant/AddPlantForm.tsx
+++ b/src/components/plant/AddPlantForm.tsx
@@ -7,11 +7,13 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import SpeciesAutosuggest from "./SpeciesAutosuggest";
+import { RoomSelect } from "./RoomSelect";
 
 type CreatePayload = {
   nickname: string;
   speciesScientific?: string | null;
   speciesCommon?: string | null;
+  room_id?: number | null;
 };
 
 export default function AddPlantForm(): JSX.Element {
@@ -19,6 +21,7 @@ export default function AddPlantForm(): JSX.Element {
   const [nickname, setNickname] = useState<string>("");
   const [speciesScientific, setSpeciesScientific] = useState<string>("");
   const [speciesCommon, setSpeciesCommon] = useState<string>("");
+  const [roomId, setRoomId] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -31,6 +34,7 @@ export default function AddPlantForm(): JSX.Element {
         nickname: nickname.trim(),
         speciesScientific: speciesScientific || null,
         speciesCommon: speciesCommon || null,
+        room_id: roomId,
       };
 
       const res = await fetch("/api/plants", {
@@ -74,6 +78,11 @@ export default function AddPlantForm(): JSX.Element {
             setSpeciesCommon(common || "");
           }}
         />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Room</Label>
+        <RoomSelect value={roomId ?? null} onChange={setRoomId} />
       </div>
 
       {errorMsg ? (

--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import * as React from "react";
+
+type Props = { plantId: number };
+
+export function EventQuickAdd({ plantId }: Props) {
+  const [note, setNote] = React.useState("");
+
+  async function add(type: "watered" | "fertilized" | "note") {
+    const payload: Record<string, unknown> = { plantId, type };
+    if (type === "note" && note.trim()) payload.note = note.trim();
+
+    const res = await fetch("/api/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      setNote("");
+      // Consumers should refetch timeline; emit custom event
+      window.dispatchEvent(new CustomEvent("flora:events:changed", { detail: { plantId } }));
+    }
+  }
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3">
+      <div className="flex gap-2">
+        <button type="button" onClick={() => add("watered")} className="h-9 rounded-md bg-primary px-3 text-sm text-primary-foreground">Watered</button>
+        <button type="button" onClick={() => add("fertilized")} className="h-9 rounded-md border px-3 text-sm">Fertilized</button>
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+          placeholder="Quick note…"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <button type="button" onClick={() => add("note")} className="h-9 rounded-md border px-3 text-sm">Add note</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plant/RoomSelect.tsx
+++ b/src/components/plant/RoomSelect.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as React from "react";
+
+type Room = { id: number; name: string }
+
+export function RoomSelect(props: {
+  value?: number | null;
+  onChange: (roomId: number | null) => void;
+}) {
+  const { value = null, onChange } = props;
+  const [rooms, setRooms] = React.useState<Room[]>([]);
+  const [newRoom, setNewRoom] = React.useState<string>("");
+  const [creating, setCreating] = React.useState(false);
+
+  React.useEffect(() => {
+    (async () => {
+      const res = await fetch("/api/rooms");
+      const data = await res.json();
+      if (Array.isArray(data)) setRooms(data as Room[]);
+    })();
+  }, []);
+
+  async function createRoom() {
+    if (!newRoom.trim()) return;
+    setCreating(true);
+    const res = await fetch("/api/rooms", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newRoom.trim() }),
+    });
+    const json = await res.json();
+    setCreating(false);
+    if (res.ok && json?.room) {
+      setRooms((r) => [...r, json.room].sort((a, b) => a.name.localeCompare(b.name)));
+      onChange(json.room.id);
+      setNewRoom("");
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <select
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+      >
+        <option value="">No room</option>
+        {rooms.map((r) => (
+          <option key={r.id} value={r.id}>
+            {r.name}
+          </option>
+        ))}
+      </select>
+
+      <div className="flex items-center gap-2">
+        <input
+          className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+          placeholder="Quick add room…"
+          value={newRoom}
+          onChange={(e) => setNewRoom(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={createRoom}
+          disabled={creating}
+          className="h-10 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {creating ? "Adding…" : "Add"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plant/Timeline.tsx
+++ b/src/components/plant/Timeline.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+
+type Event = {
+  id: number;
+  type: string;
+  note: string | null;
+  created_at: string;
+};
+
+export function Timeline({ plantId }: { plantId: number }) {
+  const [items, setItems] = React.useState<Event[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  async function load() {
+    setLoading(true);
+    const res = await fetch(`/api/events?plantId=${plantId}`);
+    const data = await res.json();
+    setItems(Array.isArray(data) ? data : []);
+    setLoading(false);
+  }
+
+  React.useEffect(() => {
+    load();
+    const handler = (e: Event | any) => load();
+    window.addEventListener("flora:events:changed", handler as any);
+    return () => window.removeEventListener("flora:events:changed", handler as any);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plantId]);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading timeline…</p>;
+  if (items.length === 0) return <p className="text-sm text-muted-foreground">No events yet.</p>;
+
+  return (
+    <ul className="space-y-4">
+      {items.map((ev) => (
+        <li key={ev.id} className="flex items-start gap-3">
+          <span>{iconFor(ev.type)}</span>
+          <div>
+            <p className="text-sm font-medium capitalize">{ev.type}</p>
+            {ev.note ? <p className="text-sm">{ev.note}</p> : null}
+            <p className="text-xs text-muted-foreground">{new Date(ev.created_at).toLocaleString()}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function iconFor(type: string) {
+  switch (type) {
+    case "watered": return "💧";
+    case "fertilized": return "🧪";
+    case "misted": return "🌫️";
+    case "rotated": return "🔁";
+    case "repotted": return "🪴";
+    case "pruned": return "✂️";
+    case "photo": return "🖼️";
+    case "note": return "📝";
+    default: return "•";
+  }
+}

--- a/supabase/migrations/20250825045101_rooms_events.sql
+++ b/supabase/migrations/20250825045101_rooms_events.sql
@@ -1,0 +1,32 @@
+-- Rooms table
+create table if not exists public.rooms (
+  id bigserial primary key,
+  name text not null unique,
+  created_at timestamptz not null default now()
+);
+
+-- Plants: add room_id if missing
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'plants' and column_name = 'room_id'
+  ) then
+    alter table public.plants add column room_id bigint references public.rooms(id) on delete set null;
+  end if;
+end $$;
+
+-- Events table (care timeline)
+create table if not exists public.events (
+  id bigserial primary key,
+  plant_id bigint not null references public.plants(id) on delete cascade,
+  type text not null check (type in ('watered','fertilized','misted','rotated','repotted','pruned','note','photo')),
+  amount numeric null,
+  note text null,
+  photo_url text null,
+  created_at timestamptz not null default now()
+);
+
+-- Helpful indexes
+create index if not exists idx_events_plant_created on public.events(plant_id, created_at desc);
+create index if not exists idx_rooms_name on public.rooms(name);


### PR DESCRIPTION
## Summary
- add Supabase migration, API routes, and components for rooms
- log plant care events via new API and timeline UI
- allow assigning plants to rooms in AddPlantForm

## Testing
- ❌ `pnpm test` (fail: multiple tests failed)


------
https://chatgpt.com/codex/tasks/task_e_68abeb7a63e883249b1c7d0d1f9a256f