### PR TITLE
feat: add notifications scaffold

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,12 @@
+# Flora Notifications Scaffold
+
+This is a lightweight scaffold for testing notifications. It does not send real emails by default.
+Configure an email provider (Resend/Postmark/etc.) and wire it in `scripts/send-reminders.ts`.
+
+## Env (example)
+RESEND_API_KEY=
+NOTIFY_FROM_EMAIL="Flora <noreply@yourdomain.com>"
+
+## Test endpoints
+- GET /api/notifications/test?to=email@example.com -> simulates a reminder payload.
+- CLI: pnpm reminders:send -> runs the script once (logs output).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "db:seed": "prisma db seed",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "reminders:send": "ts-node scripts/send-reminders.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "5.2.1",

--- a/scripts/send-reminders.ts
+++ b/scripts/send-reminders.ts
@@ -1,0 +1,18 @@
+/**
+ * Placeholder reminder sender.
+ * Integrate real email provider here (Resend/Postmark/etc.).
+ */
+async function main() {
+  const now = new Date().toISOString()
+  // TODO: fetch due/overdue tasks by querying your /api/tasks once implemented
+  const tasks = [{ to: "test@example.com", subject: "Flora — Daily digest", body: "You have 2 tasks due today." }]
+  for (const t of tasks) {
+    // eslint-disable-next-line no-console
+    console.log(`[${now}] Would send email to ${t.to}: ${t.subject} -> ${t.body}`)
+  }
+}
+main().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/api/notifications/test/route.ts
+++ b/src/app/api/notifications/test/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const to = url.searchParams.get("to") || "test@example.com"
+  // Simulated payload
+  const payload = {
+    to,
+    subject: "Flora — You have tasks due today",
+    body: "Open Flora and check your Today list.",
+    deepLink: "/today"
+  }
+  return NextResponse.json({ ok: true, payload })
+}


### PR DESCRIPTION
## Summary
- document notification testing scaffold
- add /api/notifications/test endpoint
- add placeholder reminders script and package.json hook

## Testing
- `pnpm test` *(fails: Failed to resolve import `@testing-library/jest-dom` from `test/setup.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68abed3116bc8324930678ff8d28272d