### PR TITLE
chore: add basic Playwright E2E setup

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,10 @@
+# Playwright E2E Basics
+
+## Install
+pnpm add -D @playwright/test
+pnpm exec playwright install
+
+## Run
+pnpm dev  # in one terminal
+pnpm e2e  # in another
+

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test"
+
+test("homepage has title and CTA", async ({ page }) => {
+  await page.goto("/")
+  await expect(page).toHaveTitle(/Flora/i)
+  await expect(page.getByRole("button", { name: /add a plant/i })).toBeVisible()
+})
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "db:seed": "prisma db seed",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "5.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+})
+


### PR DESCRIPTION
## Summary
- scaffold Playwright config and example spec
- add E2E test script and docs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@testing-library/jest-dom")*

------
https://chatgpt.com/codex/tasks/task_e_68abed53251c8324b9d2b2d274e8eaca