### PR TITLE
Allow builds without env vars and remove font download

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -26,13 +26,15 @@ This document is the canonical source of design standards for the Flora app. It 
 
 ```tsx
 // app/layout.tsx
-import { Inter } from "next/font/google";
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-// <html className={`${inter.variable}`}> ... </html>
+<head>
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
+  />
+</head>
 
 // app/globals.css
-:root { --font-inter: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji"; }
-.body { font-family: var(--font-inter); }
+body { font-family: 'Inter', sans-serif; }
 ```
 
 ### 2.2 Color & Theming (with `next-themes` + shadcn tokens)

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,13 +1,13 @@
 import cloudinary from "@/lib/cloudinary";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function DELETE(
-  _req: Request,
-  { params }: { params: { id: string } },
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const id = params.id;
+  const { id } = await params;
   try {
     const userId = await getCurrentUserId();
     const { data, error } = await supabaseAdmin

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,9 @@
     
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: 'Inter', sans-serif;
+    @apply antialiased;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,17 @@
 import type { ReactNode } from 'react';
-import { Inter } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from 'sonner';
 
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-});
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className={inter.variable}>
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
+        />
+      </head>
       <body className="bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,13 +1,13 @@
-const required = (name: string): string => {
-  const value = process.env[name];
+const required = (name: string, defaultValue?: string): string => {
+  const value = process.env[name] ?? defaultValue;
   if (!value) {
     throw new Error(`Missing environment variable: ${name}`);
   }
   return value;
 };
 
-export const baseUrl = required("NEXT_PUBLIC_BASE_URL");
-export const appName = required("NEXT_PUBLIC_APP_NAME");
+export const baseUrl = required("NEXT_PUBLIC_BASE_URL", "http://localhost:3000");
+export const appName = required("NEXT_PUBLIC_APP_NAME", "Flora");
 export const isDev = process.env.NODE_ENV !== "production";
 
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,2 +1,2 @@
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";
 // If your components use next/navigation, you may need to mock it per test.


### PR DESCRIPTION
## Summary
- make config use default values when env vars are missing
- load Inter font via Google Fonts link instead of Next.js font import
- avoid Tailwind @apply error in globals.css
- support new Next.js route param API in events delete handler
- document updated font usage
- fix jest-dom import for Vitest setup

## Testing
- `pnpm build`
- `pnpm test` *(fails: tests/species.api.test.ts > GET /api/species > evicts the oldest entry when cache exceeds limit)*

------
https://chatgpt.com/codex/tasks/task_e_68abedae38cc83248b4036c4def41006