### PR TITLE
Update navigation Add link

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,7 +18,7 @@ const links: NavLink[] = [
   { href: '/', label: 'Home' },
   { href: '/plants', label: 'Plants' },
   { href: '/dashboard', label: 'Dashboard' },
-  { href: '/add', label: 'Add' },
+  { href: '/plants/new', label: 'Add' },
 ];
 
 export default function Navigation() {

--- a/tests/navigation.test.tsx
+++ b/tests/navigation.test.tsx
@@ -29,7 +29,7 @@ describe('Navigation', () => {
     expect(html).toContain('href="/"');
     expect(html).toContain('href="/plants"');
     expect(html).toContain('href="/dashboard"');
-    expect(html).toContain('href="/add"');
+    expect(html).toContain('href="/plants/new"');
   });
 
   it('highlights the active route', () => {


### PR DESCRIPTION
## Summary
- use `/plants/new` for the Add link in navigation
- adjust navigation test to expect updated path

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import `@testing-library/jest-dom/vitest` from `test/setup.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac61d83ec08324bbe4d2bf5cf4a4b4