### PR TITLE
feat: load user profile and feature flags

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -29,7 +29,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ## 0. First Run & Setup
 - [x] Detect user theme and load fonts
-- [ ] Load user profile and feature flags
+- [x] Load user profile and feature flags
 - [ ] Request location permission and cache city/lat/lon
 - [ ] Fetch and cache weather data (30–60 min)
 - [x] Render empty state with CTA to add first plant

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export async function GET() {
+  try {
+    const userId = await getCurrentUserId();
+    const supabase = supabaseServer();
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("feature_flags")
+      .eq("id", userId)
+      .single();
+    if (error || !data) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      { id: userId, featureFlags: (data.feature_flags as Record<string, unknown>) || {} },
+      { status: 200 },
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}
+

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,1 +1,13 @@
-// Placeholder for lib/supabase/client.ts
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Client-side Supabase instance using the public anon key.
+ *
+ * When environment variables are missing, falls back to dummy values so that
+ * tests and Storybook can run without real credentials.
+ */
+export const supabaseClient = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "anon-key",
+);
+

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,1 +1,16 @@
-// Placeholder for lib/supabase/server.ts
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Server-side Supabase client using the service role key.
+ *
+ * Defaults to localhost values when environment variables are missing so that
+ * tests can run without real credentials.
+ */
+export function supabaseServer() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost",
+    process.env.SUPABASE_SERVICE_ROLE_KEY || "service-role-key",
+    { auth: { persistSession: false } },
+  );
+}
+

--- a/tests/profile.api.test.ts
+++ b/tests/profile.api.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => Promise.resolve("user-123"),
+}));
+
+let returnData: { feature_flags: Record<string, unknown> } | null;
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: () =>
+            Promise.resolve(
+              returnData
+                ? { data: returnData, error: null }
+                : { data: null, error: { message: "not found" } },
+            ),
+        }),
+      }),
+    }),
+  }),
+}));
+
+describe("GET /api/profile", () => {
+  beforeEach(() => {
+    returnData = { feature_flags: { beta: true } };
+  });
+
+  it("returns profile data with feature flags", async () => {
+    const { GET } = await import("../src/app/api/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ id: "user-123", featureFlags: { beta: true } });
+  });
+
+  it("returns 404 when profile not found", async () => {
+    returnData = null;
+    const { GET } = await import("../src/app/api/profile/route");
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add helper for server-side Supabase access
- expose client Supabase instance
- implement `/api/profile` to return profile and feature flags
- mark profile loading task as complete
- add tests for profile endpoint

## Testing
- `pnpm lint`
- `pnpm test` *(fails: events.api, plants.api, species.api, etc.)*
- `pnpm test tests/profile.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac6240cec483249e7bb49a2a74a237