### PR TITLE
Use prefix matching for navigation links

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -28,7 +28,13 @@ export default function Navigation() {
   return (
     <nav aria-label="Main" className="flex gap-4">
       {links.map(({ href, label }) => (
-        <Link key={href} href={href} aria-current={pathname === href ? 'page' : undefined}>
+        <Link
+          key={href}
+          href={href}
+          aria-current={
+            href === '/' ? (pathname === '/' ? 'page' : undefined) : pathname.startsWith(href) ? 'page' : undefined
+          }
+        >
           {label}
         </Link>
       ))}

--- a/tests/navigation.test.tsx
+++ b/tests/navigation.test.tsx
@@ -38,6 +38,22 @@ describe('Navigation', () => {
     expect(html).toMatch(/href="\/plants"[^>]*aria-current="page"/);
   });
 
+  it('highlights nested routes', () => {
+    pathname = '/plants/123';
+    const html = renderToString(<Navigation />);
+    expect(html).toMatch(/href="\/plants"[^>]*aria-current="page"/);
+  });
+
+  it('only highlights home on the root path', () => {
+    pathname = '/';
+    const rootHtml = renderToString(<Navigation />);
+    expect(rootHtml).toMatch(/href="\/"[^>]*aria-current="page"/);
+
+    pathname = '/plants';
+    const plantsHtml = renderToString(<Navigation />);
+    expect(plantsHtml).not.toMatch(/href="\/"[^>]*aria-current="page"/);
+  });
+
   it('renders theme toggle button', () => {
     const html = renderToString(<Navigation />);
     expect(html).toContain('Toggle theme');


### PR DESCRIPTION
## Summary
- highlight navigation links when pathname starts with their href
- keep home link active only on root path
- test navigation for nested and root paths

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 200 to be 400, TypeError DELETE is not a function, etc.)*
- `pnpm test tests/navigation.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac65f94a488324ac2c390813906b8d