### PR TITLE
feat: cache location and weather

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -30,8 +30,8 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 0. First Run & Setup
 - [x] Detect user theme and load fonts
 - [x] Load user profile and feature flags
-- [ ] Request location permission and cache city/lat/lon
-- [ ] Fetch and cache weather data (30–60 min)
+- [x] Request location permission and cache city/lat/lon
+- [x] Fetch and cache weather data (30–60 min)
 - [x] Render empty state with CTA to add first plant
 
 **Empty State Example:**

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from 'sonner';
 import Navigation from '@/components/Navigation';
+import LocationProvider from '@/components/LocationProvider';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -15,6 +16,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body className="flex min-h-screen flex-col bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <LocationProvider />
           <Navigation />
           <main className="flex-1">{children}</main>
           <Toaster richColors />

--- a/src/components/LocationProvider.tsx
+++ b/src/components/LocationProvider.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getLocation } from '@/lib/location';
+import { getWeather } from '@/lib/weather';
+
+export default function LocationProvider() {
+  useEffect(() => {
+    async function init() {
+      const loc = await getLocation();
+      if (loc) {
+        await getWeather(loc.lat, loc.lon);
+      }
+    }
+    init();
+  }, []);
+  return null;
+}

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -1,0 +1,48 @@
+export type UserLocation = {
+  city: string;
+  lat: number;
+  lon: number;
+};
+
+const LOCATION_KEY = 'flora.location';
+
+export async function getLocation(): Promise<UserLocation | null> {
+  if (typeof window === 'undefined' || !navigator.geolocation) {
+    return null;
+  }
+
+  const cached = localStorage.getItem(LOCATION_KEY);
+  if (cached) {
+    try {
+      return JSON.parse(cached) as UserLocation;
+    } catch {
+      localStorage.removeItem(LOCATION_KEY);
+    }
+  }
+
+  try {
+    const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject);
+    });
+    const { latitude, longitude } = position.coords;
+
+    let city = '';
+    try {
+      const res = await fetch(
+        `https://geocoding-api.open-meteo.com/v1/reverse?latitude=${latitude}&longitude=${longitude}&count=1`
+      );
+      if (res.ok) {
+        const json = await res.json();
+        city = json?.results?.[0]?.name ?? '';
+      }
+    } catch {
+      // ignore geocoding errors
+    }
+
+    const location: UserLocation = { city, lat: latitude, lon: longitude };
+    localStorage.setItem(LOCATION_KEY, JSON.stringify(location));
+    return location;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,0 +1,40 @@
+import type { WeatherDay } from '@/types/forecast';
+
+const WEATHER_KEY = 'flora.weather';
+const WEATHER_TTL = 30 * 60 * 1000; // 30 minutes
+
+type WeatherCache = {
+  lat: number;
+  lon: number;
+  timestamp: number;
+  data: WeatherDay[];
+};
+
+export async function getWeather(lat: number, lon: number): Promise<WeatherDay[]> {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  const cached = localStorage.getItem(WEATHER_KEY);
+  if (cached) {
+    try {
+      const parsed = JSON.parse(cached) as WeatherCache;
+      if (
+        parsed.lat === lat &&
+        parsed.lon === lon &&
+        Date.now() - parsed.timestamp < WEATHER_TTL
+      ) {
+        return parsed.data;
+      }
+    } catch {
+      localStorage.removeItem(WEATHER_KEY);
+    }
+  }
+  const res = await fetch(`/api/weather?lat=${lat}&lon=${lon}`);
+  if (!res.ok) {
+    return [];
+  }
+  const data: WeatherDay[] = await res.json();
+  const cache: WeatherCache = { lat, lon, timestamp: Date.now(), data };
+  localStorage.setItem(WEATHER_KEY, JSON.stringify(cache));
+  return data;
+}


### PR DESCRIPTION
## Summary
- request and cache user location via browser geolocation with reverse geocoding
- fetch weather data for cached coordinates with 30 minute TTL
- hook location/weather loading into app layout and update task checklist

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 200 to be 400, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac662314588324ac586ec60759d80b