### PR TITLE
feat: add form validation

### DIFF
--- a/__tests__/add-plant-form.test.tsx
+++ b/__tests__/add-plant-form.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import AddPlantForm from "@/components/plant/AddPlantForm";
 
 (globalThis as unknown as { React: typeof React }).React = React;
@@ -9,11 +9,17 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+const originalFetch = global.fetch;
+
 beforeEach(() => {
   // stub fetch to avoid network calls from RoomSelect
   global.fetch = vi.fn(() =>
     Promise.resolve({ json: () => Promise.resolve([]) })
   ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
 });
 
 describe("AddPlantForm optional details", () => {
@@ -26,5 +32,19 @@ describe("AddPlantForm optional details", () => {
     expect(screen.getByLabelText(/light/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/photo/i)).toBeInTheDocument();
+  });
+});
+
+describe("AddPlantForm validation", () => {
+  it("shows errors when required fields are missing", () => {
+    render(<AddPlantForm />);
+    fireEvent.click(screen.getByRole("button", { name: /create plant/i }));
+    expect(
+      screen.getByText(/please enter a nickname/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/please select a species/i),
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -54,8 +54,8 @@ export function EmptyToday() {
 ## 1. Add a Plant (`/plants/new`)
 - [x] Build form with nickname and species autosuggest
 - [x] Implement optional detail expanders (room, pot, light, notes, photo)
-- [ ] Call AI preview endpoint after species selection
-- [ ] Validate inputs and handle inline errors
+- [x] Call AI preview endpoint after species selection
+- [x] Validate inputs and handle inline errors
 - [ ] Submit plant to backend and redirect to detail page
 
 **Form Example:**

--- a/src/components/plant/AddPlantForm.tsx
+++ b/src/components/plant/AddPlantForm.tsx
@@ -34,6 +34,7 @@ export default function AddPlantForm(): JSX.Element {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [carePreview, setCarePreview] = useState<string | null>(null);
   const [_previewing, setPreviewing] = useState<boolean>(false);
+  const [errors, setErrors] = useState<{ nickname?: string; species?: string }>({});
 
   async function fetchPreview(scientific: string, common?: string) {
     setCarePreview(null);
@@ -54,8 +55,19 @@ export default function AddPlantForm(): JSX.Element {
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setSubmitting(true);
     setErrorMsg(null);
+
+    const newErrors: { nickname?: string; species?: string } = {};
+    if (!nickname.trim()) newErrors.nickname = "Please enter a nickname";
+    if (!speciesScientific && !speciesCommon)
+      newErrors.species = "Please select a species";
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+    setErrors({});
+
+    setSubmitting(true);
     try {
       const payload: CreatePayload = {
         nickname: nickname.trim(),
@@ -93,10 +105,15 @@ export default function AddPlantForm(): JSX.Element {
           id="nickname"
           placeholder="e.g. Kay"
           value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-          required
+          onChange={(e) => {
+            setNickname(e.target.value);
+            setErrors((er) => ({ ...er, nickname: undefined }));
+          }}
           className="h-10"
         />
+        {errors.nickname && (
+          <p className="text-sm text-destructive">{errors.nickname}</p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -106,9 +123,13 @@ export default function AddPlantForm(): JSX.Element {
           onSelect={(scientific, common) => {
             setSpeciesScientific(scientific);
             setSpeciesCommon(common || "");
+            setErrors((er) => ({ ...er, species: undefined }));
             fetchPreview(scientific, common);
           }}
         />
+        {errors.species && (
+          <p className="text-sm text-destructive">{errors.species}</p>
+        )}
       </div>
 
       {carePreview && (


### PR DESCRIPTION
## Summary
- validate nickname and species in Add Plant form with inline error messages
- update task list to reflect AI preview and validation completion
- cover validation with tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: events.api.test.ts, plants.api.test.ts, species.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b946bb48324ad4ee73ea5241c68