### PR TITLE
test: verify plant submission redirects

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -56,7 +56,7 @@ export function EmptyToday() {
 - [x] Implement optional detail expanders (room, pot, light, notes, photo)
 - [x] Call AI preview endpoint after species selection
 - [x] Validate inputs and handle inline errors
-- [ ] Submit plant to backend and redirect to detail page
+ - [x] Submit plant to backend and redirect to detail page
 
 **Form Example:**
 ```tsx


### PR DESCRIPTION
## Summary
- test plant creation posts to backend and redirects to detail page
- mark plant submission task complete in implementation guide

## Testing
- `pnpm lint`
- `pnpm test` *(fails: events.api.test.ts, plants.api.test.ts, species.api.test.ts, etc.)*
- `pnpm test __tests__/add-plant-form.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ac79c5d30483248a9140dce5a13946