### PR TITLE
feat: add mark as watered event logging

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -90,7 +90,7 @@ export function EmptyToday() {
 - [x] Layout hero image, nickname, species, and room badge
 - [x] Display quick stats for last/next watering and cadence
     - [x] Implement tabs for timeline, care plan, photos, notes
-- [ ] Add "Mark as watered" and event logging
+- [x] Add "Mark as watered" and event logging
 - [ ] Support schedule adjustments and AI suggestions
 
 **Hero + Quick Stats Example:**

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,6 +3,7 @@ import db from "@/lib/db";
 import QuickStats from "@/components/plant/QuickStats";
 import CareCoach from "@/components/plant/CareCoach";
 import PlantTabs from "@/components/plant/PlantTabs";
+import WaterPlantButton from "@/components/plant/WaterPlantButton";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { hydrateTimeline } from "@/lib/tasks";
 import { getCurrentUserId } from "@/lib/auth";
@@ -76,6 +77,7 @@ export default async function PlantDetailPage({
           )}
         </div>
         <QuickStats plant={plant} />
+        <WaterPlantButton plantId={plant.id} />
         <CareCoach plant={plant} />
         <PlantTabs plantId={plant.id} initialEvents={timelineEvents} />
       </div>

--- a/src/components/plant/PlantTabs.tsx
+++ b/src/components/plant/PlantTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { CareEvent } from '@/types';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import CareTimeline from '@/components/CareTimeline';
@@ -15,6 +15,10 @@ interface PlantTabsProps {
 
 export default function PlantTabs({ plantId, initialEvents }: PlantTabsProps) {
   const [events, setEvents] = useState<CareEvent[]>(initialEvents);
+
+  useEffect(() => {
+    setEvents(initialEvents);
+  }, [initialEvents]);
 
   function addEvent(evt: CareEvent) {
     setEvents((prev) => [evt, ...prev]);

--- a/src/components/plant/WaterPlantButton.tsx
+++ b/src/components/plant/WaterPlantButton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  plantId: string;
+}
+
+export default function WaterPlantButton({ plantId }: Props) {
+  const [saving, setSaving] = useState(false);
+  const router = useRouter();
+
+  async function handleClick() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await fetch('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plant_id: plantId, type: 'water' }),
+      });
+      router.refresh();
+    } catch (err) {
+      console.error('Failed to mark as watered', err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Button onClick={handleClick} disabled={saving} className="mt-4 w-full">
+      Mark as watered
+    </Button>
+  );
+}
+

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/lib/auth", () => ({
   getCurrentUserId: () => Promise.resolve("user-123"),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => undefined }),
+}));
+
 vi.mock("@/components/AddNoteForm", () => ({ default: () => null }));
 vi.mock("@/components/AddPhotoForm", () => ({ default: () => null }));
 vi.mock("@/components/CareTimeline", () => ({ default: () => null }));
@@ -96,6 +100,13 @@ describe("PlantDetailPage", () => {
     expect(html).toContain("My Plant");
     expect(html).toContain("Pothos");
     expect(html).toContain("Living Room");
+  });
+
+  it("renders mark as watered button", async () => {
+    const PlantDetailPage = (await import("../src/app/plants/[id]/page")).default;
+    const element = await PlantDetailPage({ params: Promise.resolve({ id: "plant-1" }) });
+    const html = renderToString(element);
+    expect(html).toContain("Mark as watered");
   });
 });
 

--- a/tests/waterplantbutton.test.tsx
+++ b/tests/waterplantbutton.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import WaterPlantButton from "../src/components/plant/WaterPlantButton";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => undefined }),
+}));
+
+describe("WaterPlantButton", () => {
+  it("renders button text", () => {
+    const html = renderToString(<WaterPlantButton plantId="1" />);
+    expect(html).toContain("Mark as watered");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add button to log watering events on plant detail page
- refresh timeline by syncing PlantTabs with new events
- mark implementation task complete

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 3 failed test files, 12 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac83e45dd48324b14c10b6b8906fc3