### PR TITLE
feat: allow schedule adjustments with ai suggestions

### DIFF
--- a/__tests__/plants.api.test.ts
+++ b/__tests__/plants.api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { GET as PlantsGET, POST as PlantsPOST } from "@/app/api/plants/route"
+import { PATCH as PlantPATCH } from "@/app/api/plants/[id]/route"
 
 // Minimal mock for @supabase/supabase-js createClient used in the route
 vi.mock("@supabase/supabase-js", () => {
@@ -24,6 +25,21 @@ vi.mock("@supabase/supabase-js", () => {
                 return {
                   single() {
                     return { data: { id: 1, nickname: "Kay" }, error: null }
+                  },
+                }
+              },
+            }
+          },
+          update(payload: any) {
+            return {
+              eq() {
+                return {
+                  select() {
+                    return {
+                      single() {
+                        return { data: { id: 1, ...payload }, error: null }
+                      },
+                    }
                   },
                 }
               },
@@ -61,5 +77,17 @@ describe("/api/plants route", () => {
     const json = await res.json()
     expect(json).toHaveProperty("plant")
     expect(json.plant).toHaveProperty("id")
+  })
+
+  it("PATCH updates a plant schedule", async () => {
+    const req = new Request("http://localhost/api/plants/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ waterEvery: "10 days" }),
+    })
+    const res = await PlantPATCH(req as unknown as Request, { params: { id: "1" } })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.plant).toHaveProperty("water_every", "10 days")
   })
 })

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -25,3 +25,23 @@ export async function GET(_req: Request, ctx: { params: { id: string } }) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export async function PATCH(req: Request, ctx: { params: { id: string } }) {
+  try {
+    const id = Number(ctx.params.id);
+    if (!id) return NextResponse.json({ error: "invalid id" }, { status: 400 });
+    const body = await req.json();
+    const supabase = supabaseServer();
+    const { data, error } = await supabase
+      .from("plants")
+      .update({ water_every: body.waterEvery ?? null })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json({ plant: data }, { status: 200 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import db from "@/lib/db";
 import QuickStats from "@/components/plant/QuickStats";
+import ScheduleAdjuster from "@/components/plant/ScheduleAdjuster";
 import CareCoach from "@/components/plant/CareCoach";
 import PlantTabs from "@/components/plant/PlantTabs";
 import WaterPlantButton from "@/components/plant/WaterPlantButton";
@@ -77,6 +78,7 @@ export default async function PlantDetailPage({
           )}
         </div>
         <QuickStats plant={plant} />
+        <ScheduleAdjuster plantId={plant.id} waterEvery={plant.waterEvery} />
         <WaterPlantButton plantId={plant.id} />
         <CareCoach plant={plant} />
         <PlantTabs plantId={plant.id} initialEvents={timelineEvents} />

--- a/src/components/plant/ScheduleAdjuster.tsx
+++ b/src/components/plant/ScheduleAdjuster.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface Props {
+  plantId: string;
+  waterEvery?: string | null;
+}
+
+export default function ScheduleAdjuster({ plantId, waterEvery }: Props) {
+  const [value, setValue] = useState(waterEvery ?? '');
+  const [saving, setSaving] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    async function fetchSuggestions() {
+      try {
+        const res = await fetch(`/api/ai-care?plantId=${plantId}`);
+        const json = await res.json();
+        if (Array.isArray(json.suggestions)) {
+          setSuggestions(json.suggestions as string[]);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    fetchSuggestions();
+  }, [plantId]);
+
+  async function onSave() {
+    setSaving(true);
+    try {
+      await fetch(`/api/plants/${plantId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ waterEvery: value || null }),
+      });
+      router.refresh();
+    } catch (err) {
+      console.error('Failed to update schedule', err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-3">
+      <div className="flex items-end gap-2">
+        <div className="flex-1 space-y-1">
+          <label className="text-sm font-medium" htmlFor="waterEvery">Water every</label>
+          <Input id="waterEvery" value={value} onChange={(e) => setValue(e.target.value)} placeholder="e.g. 7 days" />
+        </div>
+        <Button disabled={saving} onClick={onSave}>Save</Button>
+      </div>
+      {suggestions.length > 0 && (
+        <ul className="text-xs text-muted-foreground list-disc pl-5 space-y-1">
+          {suggestions.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PATCH endpoint for updating plant schedules
- integrate schedule adjuster and AI suggestions in plant detail page
- add test coverage for schedule updates

## Testing
- `pnpm lint`
- `pnpm test` *(fails: events.api.test.ts, plants.api.test.ts, species.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8c801aa083248813b4b224f4a45c