### PR TITLE
feat: segment today tasks

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -135,8 +135,8 @@ export function EmptyToday() {
 ---
 
 ## 3. Daily Care – Today (`/today`)
-- [ ] Build checklist segmented into overdue, due, and upcoming
-- [ ] Implement task cards with quick actions (done, snooze, view)
+- [x] Build checklist segmented into overdue, due, and upcoming
+- [x] Implement task cards with quick actions (done, snooze, view)
 - [ ] Recompute schedule after marking tasks done
 - [ ] Animate task completion and movement between sections
 

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -12,7 +12,13 @@ const samplePlants = [
     id: '2',
     name: 'Fiddle Leaf Fig',
     fertEvery: '30 days',
-    lastFertilizedAt: new Date(Date.now() - 31 * 86400000).toISOString(),
+    lastFertilizedAt: new Date(Date.now() - 30 * 86400000).toISOString(),
+  },
+  {
+    id: '3',
+    name: 'Snake Plant',
+    waterEvery: '14 days',
+    lastWateredAt: new Date(Date.now() - 10 * 86400000).toISOString(),
   },
 ];
 

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -24,6 +24,7 @@ export function generateWeeklyCareForecast(
         if (nextWaterStr === dateStr) {
           tasks.push({
             id: `${plant.id}-water-${dateStr}`,
+            plantId: plant.id,
             plantName: plant.name,
             type: 'water',
             due: nextWaterStr,
@@ -38,6 +39,7 @@ export function generateWeeklyCareForecast(
         if (nextFertStr === dateStr) {
           tasks.push({
             id: `${plant.id}-fertilize-${dateStr}`,
+            plantId: plant.id,
             plantName: plant.name,
             type: 'fertilize',
             due: nextFertStr,

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -36,16 +36,22 @@ export function parseInterval(value?: string | null): number | null {
   }
 }
 
-export function generateTasks(plants: Plant[], today: Date = new Date()): Task[] {
+export function generateTasks(
+  plants: Plant[],
+  today: Date = new Date(),
+  futureDays = 7
+): Task[] {
   const tasks: Task[] = [];
+  const limit = addDays(today, futureDays);
 
   for (const plant of plants) {
     const waterInterval = parseInterval(plant.waterEvery);
     if (waterInterval !== null && plant.lastWateredAt) {
       const due = addDays(parseISO(plant.lastWateredAt), waterInterval);
-      if (due <= today) {
+      if (due <= limit) {
         tasks.push({
           id: `${plant.id}-water`,
+          plantId: plant.id,
           plantName: plant.name,
           type: 'water',
           due: formatISO(due),
@@ -56,9 +62,10 @@ export function generateTasks(plants: Plant[], today: Date = new Date()): Task[]
     const fertInterval = parseInterval(plant.fertEvery);
     if (fertInterval !== null && plant.lastFertilizedAt) {
       const due = addDays(parseISO(plant.lastFertilizedAt), fertInterval);
-      if (due <= today) {
+      if (due <= limit) {
         tasks.push({
           id: `${plant.id}-fertilize`,
+          plantId: plant.id,
           plantName: plant.name,
           type: 'fertilize',
           due: formatISO(due),

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,5 +1,6 @@
 export type Task = {
   id: string;
+  plantId: string;
   plantName: string;
   type: 'water' | 'fertilize' | 'note';
   due: string; // ISO date string

--- a/tests/taskEngine.test.ts
+++ b/tests/taskEngine.test.ts
@@ -17,7 +17,7 @@ describe('generateTasks', () => {
     expect(tasks[0]).toMatchObject({ plantName: 'Monstera', type: 'water' });
   });
 
-  it('skips tasks that are not yet due', () => {
+  it('includes upcoming tasks within 7 days', () => {
     const plants = [
       {
         id: '1',
@@ -27,6 +27,19 @@ describe('generateTasks', () => {
       },
     ];
     const tasks = generateTasks(plants, new Date('2024-01-08'));
+    expect(tasks).toHaveLength(1);
+  });
+
+  it('skips tasks beyond the future window', () => {
+    const plants = [
+      {
+        id: '1',
+        name: 'Monstera',
+        waterEvery: '7 days',
+        lastWateredAt: '2024-01-01',
+      },
+    ];
+    const tasks = generateTasks(plants, new Date('2024-01-01'), 3);
     expect(tasks).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
- segment today checklist into overdue, due, and upcoming buckets
- add plant links to task cards
- update task generation to include upcoming items

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests/events.api.test.ts, tests/plants.api.test.ts, tests/species.api.test.ts, tests/taskEngine.test.ts, ...)*
- `pnpm test tests/taskEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac8e8c77c48324a832fdeb05c24d33