### PR TITLE
feat: recompute next task after completion

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -137,7 +137,7 @@ export function EmptyToday() {
 ## 3. Daily Care – Today (`/today`)
 - [x] Build checklist segmented into overdue, due, and upcoming
 - [x] Implement task cards with quick actions (done, snooze, view)
-- [ ] Recompute schedule after marking tasks done
+- [x] Recompute schedule after marking tasks done
 - [ ] Animate task completion and movement between sections
 
 **Task Row Example:**

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { getCurrentUserId } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { logEvent } from "@/lib/analytics";
 import { addDays, formatISO, parseISO } from "date-fns";
+import { parseInterval } from "@/lib/tasks";
 import { NextResponse } from "next/server";
 
 interface Params {
@@ -51,6 +52,35 @@ export async function PATCH(req: Request, { params }: Params) {
       });
       if (eventError) {
         return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      const { data: plant } = await supabaseAdmin
+        .from("plants")
+        .select("care_plan")
+        .eq("id", task.plant_id as string)
+        .eq("user_id", userId)
+        .single();
+
+      const plan = plant?.care_plan as
+        | { waterEvery?: string; fertEvery?: string }
+        | null;
+      const intervalStr =
+        task.type === "water"
+          ? plan?.waterEvery
+          : task.type === "fertilize"
+          ? plan?.fertEvery
+          : undefined;
+      const interval = parseInterval(intervalStr);
+      if (interval) {
+        const nextDue = formatISO(addDays(new Date(), interval), {
+          representation: "date",
+        });
+        await supabaseAdmin.from("tasks").insert({
+          plant_id: task.plant_id as string,
+          user_id: userId,
+          type: task.type as string,
+          due_date: nextDue,
+        });
       }
 
       await logEvent("task_completed", { task_id: id });


### PR DESCRIPTION
## Summary
- mark schedule recompute task as complete in project checklist
- recompute next task when completing a care task

## Testing
- `pnpm test` *(fails: expected status 200 but got 400/500 in several API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92f491748324b6e7fd65e3b7b88c