### PR TITLE
feat: surface AI care nudges with feedback

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -156,8 +156,8 @@ export function EmptyToday() {
 
 ## 4. AI Care Coach
 - [x] Collect environment and history data for suggestions
-- [ ] Surface AI nudges at key moments
-- [ ] Allow apply/dismiss, record feedback
+- [x] Surface AI nudges at key moments
+- [x] Allow apply/dismiss, record feedback
 
 **Nudge Example:**
 ```tsx

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -3,6 +3,7 @@ import db from "@/lib/db";
 import QuickStats from "@/components/plant/QuickStats";
 import ScheduleAdjuster from "@/components/plant/ScheduleAdjuster";
 import CareCoach from "@/components/plant/CareCoach";
+import CareSuggestion from "@/components/CareSuggestion";
 import PlantTabs from "@/components/plant/PlantTabs";
 import WaterPlantButton from "@/components/plant/WaterPlantButton";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
@@ -80,6 +81,7 @@ export default async function PlantDetailPage({
         <QuickStats plant={plant} />
         <ScheduleAdjuster plantId={plant.id} waterEvery={plant.waterEvery} />
         <WaterPlantButton plantId={plant.id} />
+        <CareSuggestion plantId={plant.id} />
         <CareCoach plant={plant} />
         <PlantTabs plantId={plant.id} initialEvents={timelineEvents} />
       </div>

--- a/src/components/CareSuggestion.tsx
+++ b/src/components/CareSuggestion.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface CareSuggestionProps {
+  plantId: string;
+}
+
+export default function CareSuggestion({ plantId }: CareSuggestionProps) {
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    async function fetchSuggestion() {
+      try {
+        const res = await fetch(`/api/ai-care?plantId=${plantId}`);
+        const json = await res.json();
+        if (Array.isArray(json.suggestions) && json.suggestions.length > 0) {
+          setSuggestion(json.suggestions[0] as string);
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    fetchSuggestion();
+  }, [plantId]);
+
+  async function sendFeedback(feedback: string) {
+    try {
+      await fetch('/api/care-feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plant_id: plantId, feedback }),
+      });
+    } catch {
+      // ignore errors
+    }
+  }
+
+  async function handleApply() {
+    await sendFeedback('applied');
+    setHidden(true);
+  }
+
+  async function handleDismiss() {
+    await sendFeedback('dismissed');
+    setHidden(true);
+  }
+
+  if (!suggestion || hidden) return null;
+
+  return (
+    <div className="rounded-md border-l-4 border-emerald-500 bg-emerald-50 p-4 text-sm">
+      <p className="font-medium">AI Suggestion</p>
+      <p className="text-muted-foreground">{suggestion}</p>
+      <div className="mt-2 flex gap-2">
+        <Button size="sm" onClick={handleApply}>Apply</Button>
+        <Button size="sm" variant="outline" onClick={handleDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add CareSuggestion component to show AI nudges and record user feedback
- surface AI care suggestion on plant detail page
- mark AI care nudge tasks as complete

## Testing
- `pnpm lint`
- `pnpm test tests/caresuggestion.test.tsx`
- `pnpm test` *(fails: events.api.test.ts, plants.api.test.ts, species.api.test.ts, tasks.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68acac61edc8832481f92e3fbb44d232