### PR TITLE
feat: highlight plants needing attention

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -185,7 +185,7 @@ Reuses Plant Detail timeline snippet above.
 
 ## 7. Dashboard & Insights (`/dashboard`)
 - [ ] Create widgets for completion rate, overdue trends, and streaks
-- [ ] Highlight plants needing attention
+- [x] Highlight plants needing attention
 
 **Dashboard Card Example:**
 ```tsx

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -21,6 +21,28 @@ export default async function DashboardPage() {
         </section>
 
         <section className="rounded-2xl border bg-card text-card-foreground p-6">
+          <h2 className="text-lg font-medium mb-4">Needs Attention</h2>
+          {stats?.attention?.length ? (
+            <ul className="space-y-3">
+              {stats.attention.map((t: any) => (
+                <li key={t.id} className="flex items-center justify-between">
+                  <div className="font-medium">{t.plantName}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {t.type === "water"
+                      ? "Water"
+                      : t.type === "fertilize"
+                      ? "Fertilize"
+                      : t.type}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">All plants are happy 🌿</p>
+          )}
+        </section>
+
+        <section className="rounded-2xl border bg-card text-card-foreground p-6">
           <h2 className="text-lg font-medium mb-4">Activity (7 days)</h2>
           <div className="grid grid-cols-7 gap-2">
             {(stats?.hist || []).map((d: any) => (


### PR DESCRIPTION
## Summary
- extend dashboard API to surface overdue plant tasks
- show needs attention section on dashboard
- mark dashboard task as complete in docs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 400 to be 200, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68acadd53fe08324b163b09a06d03fa2