### PR TITLE
feat: add room reference to plants table

### DIFF
--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -6,6 +6,7 @@ create extension if not exists pgcrypto;
 -- Plants table
 create table if not exists public.plants (
   id uuid primary key default gen_random_uuid(),
+  room_id bigint references public.rooms(id),
   user_id text not null,
   name text not null,
   species text not null,
@@ -25,6 +26,7 @@ create table if not exists public.plants (
 
 -- Ensure columns exist for existing installations
 alter table if exists public.plants add column if not exists room text;
+alter table if exists public.plants add column if not exists room_id bigint references public.rooms(id);
 alter table if exists public.plants add column if not exists common_name text;
 alter table if exists public.plants add column if not exists image_url text;
 alter table if exists public.plants add column if not exists pot_size text;


### PR DESCRIPTION
## Summary
- reference rooms from plants table via new `room_id`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 400 to be 200, etc.)*
- `psql -h localhost -U postgres -f supabase/migrations/20250825045101_rooms_events.sql` *(fails: connection refused)*
- `psql -h localhost -U postgres -c "select pg_notify('pgrst','reload schema');"` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3379ae083248668066d58c87502