### PR TITLE
feat: add plant archive and delete flows

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -199,7 +199,7 @@ Reuses Plant Detail timeline snippet above.
 
 ## 8. Edit & Maintenance
 - [x] Edit metadata, replace photo
-- [ ] Archive/delete flows
+ - [x] Archive/delete flows
 
 ---
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Plant {
   fertEvery     String?
   fertFormula   String?
   humidity      String?
+  archived      Boolean  @default(false)
 
   // relationships
   room          Room?    @relation(fields: [roomId], references: [id])

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -21,7 +21,8 @@ export async function GET(
       .from("plants")
       .select("*")
       .eq("user_id", userId)
-      .eq("id", id);
+      .eq("id", id)
+      .eq("archived", false);
     if (error || !data || data.length === 0)
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(data[0], { status: 200 });
@@ -44,6 +45,7 @@ export async function PATCH(
     if (body.name !== undefined) updates.name = body.name;
     if (body.species !== undefined) updates.species = body.species;
     if (body.image_url !== undefined) updates.image_url = body.image_url;
+    if (body.archived !== undefined) updates.archived = body.archived;
     const { data, error } = await supabase
       .from("plants")
       .update(updates)

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
     const { data, error } = await supabase
       .from("plants")
       .select("*")
+      .eq("archived", false)
       .order("created_at", { ascending: false });
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json(data, { status: 200 });

--- a/src/app/plants/[id]/edit/page.tsx
+++ b/src/app/plants/[id]/edit/page.tsx
@@ -6,8 +6,8 @@ export default async function EditPlantPage({
 }: {
   params: { id: string };
 }) {
-  const plant = await db.plant.findUnique({
-    where: { id: params.id },
+  const plant = await db.plant.findFirst({
+    where: { id: params.id, archived: false },
     select: { id: true, name: true, species: true, imageUrl: true },
   });
   if (!plant) {

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -17,8 +17,8 @@ export default async function PlantDetailPage({
 }: {
   params: { id: string };
 }) {
-  const plant = await db.plant.findUnique({
-    where: { id: params.id },
+  const plant = await db.plant.findFirst({
+    where: { id: params.id, archived: false },
     include: { room: { select: { name: true } } },
   });
   if (!plant) {

--- a/src/components/plant/EditPlantForm.tsx
+++ b/src/components/plant/EditPlantForm.tsx
@@ -45,6 +45,42 @@ export default function EditPlantForm({ plant }: { plant: Plant }) {
     }
   }
 
+  async function onArchive() {
+    if (!confirm("Archive this plant?")) return;
+    setErrorMsg(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/plants/${plant.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ archived: true }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Archive failed");
+      router.push("/");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Archive failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function onDelete() {
+    if (!confirm("Delete this plant? This cannot be undone.")) return;
+    setErrorMsg(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/plants/${plant.id}`, { method: "DELETE" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || "Delete failed");
+      router.push("/");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <form onSubmit={onSubmit} className="space-y-6">
       <div className="space-y-2">
@@ -75,9 +111,29 @@ export default function EditPlantForm({ plant }: { plant: Plant }) {
         />
       </div>
       {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
-      <Button type="submit" className="w-full h-10" disabled={submitting}>
-        {submitting ? "Saving…" : "Save Changes"}
-      </Button>
+      <div className="space-y-3">
+        <Button type="submit" className="w-full h-10" disabled={submitting}>
+          {submitting ? "Saving…" : "Save Changes"}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full h-10"
+          onClick={onArchive}
+          disabled={submitting}
+        >
+          Archive Plant
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full h-10 text-destructive border-destructive"
+          onClick={onDelete}
+          disabled={submitting}
+        >
+          Delete Plant
+        </Button>
+      </div>
     </form>
   );
 }

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -20,6 +20,7 @@ create table if not exists public.plants (
   humidity text,
   image_url text,
   care_plan jsonb,
+  archived boolean default false,
   created_at timestamptz default now()
 );
 
@@ -35,6 +36,7 @@ alter table if exists public.plants add column if not exists light_level text;
 alter table if exists public.plants add column if not exists indoor text;
 alter table if exists public.plants add column if not exists humidity text;
 alter table if exists public.plants add column if not exists user_id text not null default 'flora-single-user';
+alter table if exists public.plants add column if not exists archived boolean default false;
 
 -- Species table
 create table if not exists public.species (


### PR DESCRIPTION
## Summary
- allow archiving and deleting plants from the edit screen
- support archived flag in schema, supabase SQL, and plant APIs
- hide archived plants and mark task as complete in docs

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm prisma generate` *(fails: 403 Forbidden)*
- `pnpm test` *(fails: several tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb4c6e0f48324a97bc712aed80a69