### PR TITLE
refactor: adopt canonical plant column names

### DIFF
--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -41,8 +41,12 @@ export async function PATCH(
     const supabase = supabaseServer();
     const userId = await getCurrentUserId();
     const updates: Record<string, unknown> = {};
-    if (body.name !== undefined) updates.name = body.name;
-    if (body.species !== undefined) updates.species = body.species;
+    if (body.nickname !== undefined) updates.nickname = body.nickname;
+    if (body.species_scientific !== undefined)
+      updates.species_scientific = body.species_scientific;
+    if (body.species_common !== undefined)
+      updates.species_common = body.species_common;
+    if (body.room_id !== undefined) updates.room_id = body.room_id;
     if (body.image_url !== undefined) updates.image_url = body.image_url;
     const { data, error } = await supabase
       .from("plants")

--- a/supabase/functions/notify-tasks/index.ts
+++ b/supabase/functions/notify-tasks/index.ts
@@ -10,7 +10,7 @@ Deno.serve(async () => {
   const today = new Date().toISOString().slice(0, 10);
   const { data, error } = await supabase
     .from("tasks")
-    .select("type, plant:plants(name)")
+    .select("type, plant:plants(nickname)")
     .lte("due_date", today)
     .is("completed_at", null)
     .eq("user_id", userId);

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -8,10 +8,9 @@ create table if not exists public.plants (
   id uuid primary key default gen_random_uuid(),
   room_id bigint references public.rooms(id),
   user_id text not null,
-  name text not null,
-  species text not null,
-  room text,
-  common_name text,
+  nickname text not null,
+  species_scientific text not null,
+  species_common text,
   pot_size text,
   pot_material text,
   drainage text,
@@ -25,9 +24,17 @@ create table if not exists public.plants (
 );
 
 -- Ensure columns exist for existing installations
-alter table if exists public.plants add column if not exists room text;
+-- Rename legacy columns to canonical names
+alter table if exists public.plants rename column name to nickname;
+alter table if exists public.plants rename column species to species_scientific;
+alter table if exists public.plants rename column common_name to species_common;
+alter table if exists public.plants drop column if exists room;
+
+-- Ensure columns exist for existing installations
 alter table if exists public.plants add column if not exists room_id bigint references public.rooms(id);
-alter table if exists public.plants add column if not exists common_name text;
+alter table if exists public.plants add column if not exists species_common text;
+alter table if exists public.plants add column if not exists species_scientific text;
+alter table if exists public.plants add column if not exists nickname text;
 alter table if exists public.plants add column if not exists image_url text;
 alter table if exists public.plants add column if not exists pot_size text;
 alter table if exists public.plants add column if not exists pot_material text;

--- a/supabase/sample_data.sql
+++ b/supabase/sample_data.sql
@@ -2,28 +2,28 @@
 -- Run this in Supabase SQL editor after creating tables
 
 -- Insert sample plants
-insert into public.plants (id, user_id, name, species, common_name, room)
+insert into public.plants (id, user_id, nickname, species_scientific, species_common)
 values
-  ('00000000-0000-0000-0000-000000000001', 'flora-single-user', 'Aloe Vera', 'Aloe vera', 'Aloe', 'Living Room'),
-  ('00000000-0000-0000-0000-000000000002', 'flora-single-user', 'Fiddle Leaf Fig', 'Ficus lyrata', 'Fiddle Leaf Fig', 'Office'),
-  ('00000000-0000-0000-0000-000000000003', 'flora-single-user', 'Monstera', 'Monstera deliciosa', 'Swiss Cheese Plant', 'Bedroom'),
-  ('00000000-0000-0000-0000-000000000004', 'flora-single-user', 'Snake Plant', 'Sansevieria trifasciata', 'Snake Plant', 'Hallway'),
-  ('00000000-0000-0000-0000-000000000005', 'flora-single-user', 'Spider Plant', 'Chlorophytum comosum', 'Spider Plant', 'Kitchen'),
-  ('00000000-0000-0000-0000-000000000006', 'flora-single-user', 'Peace Lily', 'Spathiphyllum', 'Peace Lily', 'Bathroom'),
-  ('00000000-0000-0000-0000-000000000007', 'flora-single-user', 'ZZ Plant', 'Zamioculcas zamiifolia', 'ZZ Plant', 'Office'),
-  ('00000000-0000-0000-0000-000000000008', 'flora-single-user', 'Pothos', 'Epipremnum aureum', 'Pothos', 'Living Room'),
-  ('00000000-0000-0000-0000-000000000009', 'flora-single-user', 'Rubber Plant', 'Ficus elastica', 'Rubber Plant', 'Dining Room'),
-  ('00000000-0000-0000-0000-000000000010', 'flora-single-user', 'Philodendron', 'Philodendron hederaceum', 'Heartleaf Philodendron', 'Bedroom'),
-  ('00000000-0000-0000-0000-000000000011', 'flora-single-user', 'Jade Plant', 'Crassula ovata', 'Jade Plant', 'Office'),
-  ('00000000-0000-0000-0000-000000000012', 'flora-single-user', 'Boston Fern', 'Nephrolepis exaltata', 'Boston Fern', 'Bathroom'),
-  ('00000000-0000-0000-0000-000000000013', 'flora-single-user', 'Chinese Evergreen', 'Aglaonema', 'Chinese Evergreen', 'Hallway'),
-  ('00000000-0000-0000-0000-000000000014', 'flora-single-user', 'Dracaena', 'Dracaena marginata', 'Dragon Tree', 'Living Room'),
-  ('00000000-0000-0000-0000-000000000015', 'flora-single-user', 'English Ivy', 'Hedera helix', 'English Ivy', 'Kitchen'),
-  ('00000000-0000-0000-0000-000000000016', 'flora-single-user', 'Bird of Paradise', 'Strelitzia reginae', 'Bird of Paradise', 'Sunroom'),
-  ('00000000-0000-0000-0000-000000000017', 'flora-single-user', 'Bamboo Palm', 'Chamaedorea seifrizii', 'Bamboo Palm', 'Office'),
-  ('00000000-0000-0000-0000-000000000018', 'flora-single-user', 'Croton', 'Codiaeum variegatum', 'Croton', 'Living Room'),
-  ('00000000-0000-0000-0000-000000000019', 'flora-single-user', 'Prayer Plant', 'Maranta leuconeura', 'Prayer Plant', 'Bedroom'),
-  ('00000000-0000-0000-0000-000000000020', 'flora-single-user', 'Succulent Mix', 'Various', 'Succulent Mix', 'Desk')
+  ('00000000-0000-0000-0000-000000000001', 'flora-single-user', 'Aloe Vera', 'Aloe vera', 'Aloe'),
+  ('00000000-0000-0000-0000-000000000002', 'flora-single-user', 'Fiddle Leaf Fig', 'Ficus lyrata', 'Fiddle Leaf Fig'),
+  ('00000000-0000-0000-0000-000000000003', 'flora-single-user', 'Monstera', 'Monstera deliciosa', 'Swiss Cheese Plant'),
+  ('00000000-0000-0000-0000-000000000004', 'flora-single-user', 'Snake Plant', 'Sansevieria trifasciata', 'Snake Plant'),
+  ('00000000-0000-0000-0000-000000000005', 'flora-single-user', 'Spider Plant', 'Chlorophytum comosum', 'Spider Plant'),
+  ('00000000-0000-0000-0000-000000000006', 'flora-single-user', 'Peace Lily', 'Spathiphyllum', 'Peace Lily'),
+  ('00000000-0000-0000-0000-000000000007', 'flora-single-user', 'ZZ Plant', 'Zamioculcas zamiifolia', 'ZZ Plant'),
+  ('00000000-0000-0000-0000-000000000008', 'flora-single-user', 'Pothos', 'Epipremnum aureum', 'Pothos'),
+  ('00000000-0000-0000-0000-000000000009', 'flora-single-user', 'Rubber Plant', 'Ficus elastica', 'Rubber Plant'),
+  ('00000000-0000-0000-0000-000000000010', 'flora-single-user', 'Philodendron', 'Philodendron hederaceum', 'Heartleaf Philodendron'),
+  ('00000000-0000-0000-0000-000000000011', 'flora-single-user', 'Jade Plant', 'Crassula ovata', 'Jade Plant'),
+  ('00000000-0000-0000-0000-000000000012', 'flora-single-user', 'Boston Fern', 'Nephrolepis exaltata', 'Boston Fern'),
+  ('00000000-0000-0000-0000-000000000013', 'flora-single-user', 'Chinese Evergreen', 'Aglaonema', 'Chinese Evergreen'),
+  ('00000000-0000-0000-0000-000000000014', 'flora-single-user', 'Dracaena', 'Dracaena marginata', 'Dragon Tree'),
+  ('00000000-0000-0000-0000-000000000015', 'flora-single-user', 'English Ivy', 'Hedera helix', 'English Ivy'),
+  ('00000000-0000-0000-0000-000000000016', 'flora-single-user', 'Bird of Paradise', 'Strelitzia reginae', 'Bird of Paradise'),
+  ('00000000-0000-0000-0000-000000000017', 'flora-single-user', 'Bamboo Palm', 'Chamaedorea seifrizii', 'Bamboo Palm'),
+  ('00000000-0000-0000-0000-000000000018', 'flora-single-user', 'Croton', 'Codiaeum variegatum', 'Croton'),
+  ('00000000-0000-0000-0000-000000000019', 'flora-single-user', 'Prayer Plant', 'Maranta leuconeura', 'Prayer Plant'),
+  ('00000000-0000-0000-0000-000000000020', 'flora-single-user', 'Succulent Mix', 'Various', 'Succulent Mix')
 on conflict (id) do nothing;
 
 -- Insert sample tasks (overdue, due today, upcoming)


### PR DESCRIPTION
## Summary
- rename plant columns to canonical `nickname`, `species_scientific`, `species_common`
- drop legacy `room` field and add migration rename statements
- adjust plant update API, sample data, and notify-tasks function

## Testing
- `pnpm test` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68acb51b73fc83249ee2599d7a7ca9d6