### PR TITLE
feat: use bigint room id

### DIFF
--- a/prisma/migrations/20250214000000_room-id-bigint/migration.sql
+++ b/prisma/migrations/20250214000000_room-id-bigint/migration.sql
@@ -1,0 +1,68 @@
+-- CreateTable
+CREATE TABLE "Plant" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "species" TEXT,
+  "roomId" BIGINT,
+  "imageUrl" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "waterEvery" TEXT,
+  "waterAmount" TEXT,
+  "fertEvery" TEXT,
+  "fertFormula" TEXT,
+  "humidity" TEXT,
+  "archived" BOOLEAN NOT NULL DEFAULT false,
+
+  CONSTRAINT "Plant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Room" (
+  "id" BIGSERIAL NOT NULL,
+  "name" TEXT NOT NULL,
+
+  CONSTRAINT "Room_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CareEvent" (
+  "id" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "date" TIMESTAMP(3) NOT NULL,
+  "plantId" TEXT NOT NULL,
+
+  CONSTRAINT "CareEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Note" (
+  "id" TEXT NOT NULL,
+  "content" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "plantId" TEXT NOT NULL,
+
+  CONSTRAINT "Note_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Photo" (
+  "id" TEXT NOT NULL,
+  "url" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "plantId" TEXT NOT NULL,
+
+  CONSTRAINT "Photo_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Plant" ADD CONSTRAINT "Plant_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CareEvent" ADD CONSTRAINT "CareEvent_plantId_fkey" FOREIGN KEY ("plantId") REFERENCES "Plant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Note" ADD CONSTRAINT "Note_plantId_fkey" FOREIGN KEY ("plantId") REFERENCES "Plant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Photo" ADD CONSTRAINT "Photo_plantId_fkey" FOREIGN KEY ("plantId") REFERENCES "Plant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ model Plant {
   id            String   @id @default(cuid())
   name          String
   species       String?
-  roomId        String?
+  roomId        BigInt?
   imageUrl      String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
@@ -32,7 +32,7 @@ model Plant {
 }
 
 model Room {
-  id     String  @id @default(cuid())
+  id     BigInt  @id @default(autoincrement())
   name   String
   plants Plant[]
 }


### PR DESCRIPTION
## Summary
- use `BigInt` for `Room.id`
- use `BigInt` for `Plant.roomId`
- add initial Prisma migration for updated IDs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: default.plant.findFirst is not a function)*
- `prisma migrate dev --name room-id-bigint` *(fails: Failed to fetch the engine file)*

------
https://chatgpt.com/codex/tasks/task_e_68acb70854988324a12795a165ecc705