### PR TITLE
feat: show empty today state

### DIFF
--- a/__tests__/task-list.test.tsx
+++ b/__tests__/task-list.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import TaskList from "@/components/TaskList";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock("canvas-confetti", () => ({
+  __esModule: true,
+  default: () => {},
+}));
+
+vi.mock("framer-motion", () => ({
+  __esModule: true,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    li: (props: any) => <li {...props} />,
+    ul: (props: any) => <ul {...props} />,
+    div: (props: any) => <div {...props} />,
+  },
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("TaskList empty state", () => {
+  it("shows call to add a plant when no tasks", () => {
+    render(<TaskList tasks={[]} />);
+    expect(screen.getByText(/No plants yet/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /Add a Plant/i });
+    expect(link).toHaveAttribute("href", "/plants/new");
+  });
+});

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -138,7 +138,8 @@ export function EmptyToday() {
 - [x] Build checklist segmented into overdue, due, and upcoming
 - [x] Implement task cards with quick actions (done, snooze, view)
 - [x] Recompute schedule after marking tasks done
- - [x] Animate task completion and movement between sections
+- [x] Animate task completion and movement between sections
+- [x] Show empty state with CTA when there are no tasks
 
 **Task Row Example:**
 ```tsx

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link';
 import type { Task } from '@/types/task';
 import { Button } from '@/components/ui/button';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
+import EmptyPlantState from '@/components/EmptyPlantState';
 
 function playChime() {
   if (typeof window === 'undefined') return;
@@ -39,7 +40,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
   const [tasks, setTasks] = useState(initialTasks);
 
   if (!tasks || tasks.length === 0) {
-    return <p className="text-sm text-muted-foreground">No tasks for today.</p>;
+    return <EmptyPlantState />;
   }
 
   const handleComplete = async (id: string) => {


### PR DESCRIPTION
## Summary
- show an empty-state call to action when Today has no tasks
- document the empty Today state in implementation tasks
- add unit test for empty Today view

## Testing
- `pnpm lint`
- `pnpm test` *(fails: default.plant.findFirst is not a function, expected 500 to be 200, etc.)*
- `pnpm test __tests__/task-list.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acb6ecf9748324993b595938091f54