### PR TITLE
feat: add empty tasks state

### DIFF
--- a/__tests__/task-list.test.tsx
+++ b/__tests__/task-list.test.tsx
@@ -33,7 +33,7 @@ vi.mock("next/link", () => ({
 describe("TaskList empty state", () => {
   it("shows call to add a plant when no tasks", () => {
     render(<TaskList tasks={[]} />);
-    expect(screen.getByText(/No plants yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /Add a Plant/i });
     expect(link).toHaveAttribute("href", "/plants/new");
   });

--- a/src/components/EmptyTasksState.tsx
+++ b/src/components/EmptyTasksState.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function EmptyTasksState() {
+  return (
+    <div className="py-20 text-center space-y-4">
+      <p className="text-lg font-medium">You&apos;re all caught up 🎉</p>
+      <p className="text-sm text-muted-foreground">
+        Add more plants to get new tasks.
+      </p>
+      <Button asChild className="px-4 py-2 text-sm font-medium">
+        <Link href="/plants/new">Add a Plant</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 import type { Task } from '@/types/task';
 import { Button } from '@/components/ui/button';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
-import EmptyPlantState from '@/components/EmptyPlantState';
+import EmptyTasksState from '@/components/EmptyTasksState';
 
 function playChime() {
   if (typeof window === 'undefined') return;
@@ -40,7 +40,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
   const [tasks, setTasks] = useState(initialTasks);
 
   if (!tasks || tasks.length === 0) {
-    return <EmptyPlantState />;
+    return <EmptyTasksState />;
   }
 
   const handleComplete = async (id: string) => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as EventsSection } from './EventsSection';
 export { default as TaskList } from './TaskList';
 export { default as Navigation } from './Navigation';
 export { default as EmptyPlantState } from './EmptyPlantState';
+export { default as EmptyTasksState } from './EmptyTasksState';


### PR DESCRIPTION
## Summary
- show a friendly empty state when no tasks are scheduled
- cover empty state messaging with updated test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 500 to be 200 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68acba2a96c883248b4e6bbff3f5dd22