### PR TITLE
test: cover notifications test endpoint

### DIFF
--- a/tests/notifications.api.test.ts
+++ b/tests/notifications.api.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+
+describe("GET /api/notifications/test", () => {
+  it("returns a simulated reminder payload with a provided recipient", async () => {
+    const { GET } = await import("../src/app/api/notifications/test/route");
+    const req = new Request("http://localhost/api/notifications/test?to=user@example.com");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: true,
+      payload: {
+        to: "user@example.com",
+        subject: "Flora — You have tasks due today",
+        body: "Open Flora and check your Today list.",
+        deepLink: "/today",
+      },
+    });
+  });
+
+  it("falls back to a default test address when none provided", async () => {
+    const { GET } = await import("../src/app/api/notifications/test/route");
+    const req = new Request("http://localhost/api/notifications/test");
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.payload.to).toBe("test@example.com");
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add unit tests verifying notifications test endpoint returns expected payload

## Testing
- `pnpm lint tests/notifications.api.test.ts src/app/api/notifications/test/route.ts`
- `pnpm test tests/notifications.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acbb7b8b0083248b3a101a9bd82a46