### PR TITLE
refactor: align Plant schema with Supabase fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,19 +10,20 @@ datasource db {
 }
 
 model Plant {
-  id            String   @id @default(cuid())
-  name          String
-  species       String?
-  roomId        BigInt?
-  imageUrl      String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  waterEvery    String?
-  waterAmount   String?
-  fertEvery     String?
-  fertFormula   String?
-  humidity      String?
-  archived      Boolean  @default(false)
+  id               String   @id @default(uuid()) @db.Uuid
+  nickname         String
+  speciesScientific String?
+  speciesCommon    String?
+  roomId           BigInt?  @db.BigInt
+  imageUrl         String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  waterEvery       String?
+  waterAmount      String?
+  fertEvery        String?
+  fertFormula      String?
+  humidity         String?
+  archived         Boolean  @default(false)
 
   // relationships
   room          Room?    @relation(fields: [roomId], references: [id])
@@ -32,7 +33,7 @@ model Plant {
 }
 
 model Room {
-  id     BigInt  @id @default(autoincrement())
+  id     BigInt  @id @default(autoincrement()) @db.BigInt
   name   String
   plants Plant[]
 }
@@ -42,7 +43,7 @@ model CareEvent {
   type      String   // "water", "fertilize", etc.
   date      DateTime
   plant     Plant    @relation(fields: [plantId], references: [id])
-  plantId   String
+  plantId   String   @db.Uuid
 }
 
 model Note {
@@ -50,7 +51,7 @@ model Note {
   content   String
   createdAt DateTime @default(now())
   plant     Plant    @relation(fields: [plantId], references: [id])
-  plantId   String
+  plantId   String   @db.Uuid
 }
 
 model Photo {
@@ -58,5 +59,5 @@ model Photo {
   url       String
   createdAt DateTime @default(now())
   plant     Plant    @relation(fields: [plantId], references: [id])
-  plantId   String
+  plantId   String   @db.Uuid
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -21,8 +21,8 @@ async function main() {
   // Create plants
   await prisma.plant.create({
     data: {
-      name: "Fiona the Fern",
-      species: "Nephrolepis exaltata",
+      nickname: "Fiona the Fern",
+      speciesScientific: "Nephrolepis exaltata",
       roomId: livingRoom.id,
       waterEvery: "7 days",
       waterAmount: "250ml",
@@ -39,8 +39,8 @@ async function main() {
 
   await prisma.plant.create({
     data: {
-      name: "Spike",
-      species: "Carnegiea gigantea",
+      nickname: "Spike",
+      speciesScientific: "Carnegiea gigantea",
       roomId: kitchen.id,
       waterEvery: "14 days",
       humidity: "low",

--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -7,8 +7,9 @@ import Image from "next/image";
 
 interface Plant {
   id: string;
-  name: string;
-  species?: string | null;
+  nickname: string;
+  speciesScientific?: string | null;
+  speciesCommon?: string | null;
   imageUrl?: string | null;
   room?: { id: string; name: string } | null;
 }
@@ -74,10 +75,10 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
                       <div className="h-12 w-12 rounded-lg bg-muted" />
                     )}
                     <div>
-                      <p className="font-medium">{plant.name}</p>
-                      {plant.species && (
+                      <p className="font-medium">{plant.nickname}</p>
+                      {(plant.speciesScientific || plant.speciesCommon) && (
                         <p className="text-sm text-muted-foreground">
-                          {plant.species}
+                          {plant.speciesScientific || plant.speciesCommon}
                         </p>
                       )}
                     </div>

--- a/src/app/plants/[id]/edit/page.tsx
+++ b/src/app/plants/[id]/edit/page.tsx
@@ -8,7 +8,7 @@ export default async function EditPlantPage({
 }) {
   const plant = await db.plant.findFirst({
     where: { id: params.id, archived: false },
-    select: { id: true, name: true, species: true, imageUrl: true },
+    select: { id: true, nickname: true, speciesScientific: true, imageUrl: true },
   });
   if (!plant) {
     return <div className="p-4 md:p-6 max-w-md mx-auto">Plant not found</div>;

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function PlantDetailPage({
       {heroUrl ? (
         <Image
           src={heroUrl}
-          alt={plant.name}
+          alt={plant.nickname}
           width={800}
           height={400}
           className="h-48 w-full rounded-xl object-cover md:h-64"
@@ -69,9 +69,11 @@ export default async function PlantDetailPage({
       <div className="p-4 md:p-6 max-w-3xl mx-auto">
         <div className="mt-4 flex items-center justify-between">
           <div>
-            <h2 className="text-xl font-semibold">{plant.name}</h2>
-            {plant.species && (
-              <p className="text-sm text-muted-foreground">{plant.species}</p>
+            <h2 className="text-xl font-semibold">{plant.nickname}</h2>
+            {(plant.speciesScientific || plant.speciesCommon) && (
+              <p className="text-sm text-muted-foreground">
+                {plant.speciesScientific || plant.speciesCommon}
+              </p>
             )}
           </div>
           <div className="flex items-center gap-2">

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -5,7 +5,7 @@ import EmptyPlantState from '@/components/EmptyPlantState';
 export default async function PlantsPage() {
   const { data: plants, error } = await supabaseAdmin
     .from('plants')
-    .select('id, name, species, image_url, room:rooms(id, name)');
+    .select('id, nickname, species_scientific, species_common, image_url, room:rooms(id, name)');
 
   if (error) {
     return (
@@ -16,8 +16,9 @@ export default async function PlantsPage() {
   const mappedPlants =
     plants?.map((p) => ({
       id: p.id,
-      name: p.name,
-      species: p.species,
+      nickname: p.nickname as string,
+      speciesScientific: p.species_scientific as string | null,
+      speciesCommon: p.species_common as string | null,
       imageUrl: p.image_url as string | null,
       room: p.room as { id: string; name: string } | null,
     })) ?? [];

--- a/src/components/plant/EditPlantForm.tsx
+++ b/src/components/plant/EditPlantForm.tsx
@@ -8,15 +8,15 @@ import { Button } from "@/components/ui/button";
 
 type Plant = {
   id: string;
-  name: string;
-  species: string | null;
+  nickname: string;
+  speciesScientific: string | null;
   imageUrl: string | null;
 };
 
 export default function EditPlantForm({ plant }: { plant: Plant }) {
   const router = useRouter();
-  const [name, setName] = useState(plant.name);
-  const [species, setSpecies] = useState(plant.species ?? "");
+  const [nickname, setNickname] = useState(plant.nickname);
+  const [speciesScientific, setSpeciesScientific] = useState(plant.speciesScientific ?? "");
   const [imageUrl, setImageUrl] = useState(plant.imageUrl ?? "");
   const [submitting, setSubmitting] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -30,8 +30,8 @@ export default function EditPlantForm({ plant }: { plant: Plant }) {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          name: name.trim(),
-          species: species.trim() || null,
+          nickname: nickname.trim(),
+          species_scientific: speciesScientific.trim() || null,
           image_url: imageUrl.trim() || null,
         }),
       });
@@ -84,20 +84,20 @@ export default function EditPlantForm({ plant }: { plant: Plant }) {
   return (
     <form onSubmit={onSubmit} className="space-y-6">
       <div className="space-y-2">
-        <Label htmlFor="name">Nickname</Label>
+        <Label htmlFor="nickname">Nickname</Label>
         <Input
-          id="name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          id="nickname"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
           className="h-10"
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="species">Species</Label>
+        <Label htmlFor="speciesScientific">Species</Label>
         <Input
-          id="species"
-          value={species}
-          onChange={(e) => setSpecies(e.target.value)}
+          id="speciesScientific"
+          value={speciesScientific}
+          onChange={(e) => setSpeciesScientific(e.target.value)}
           className="h-10"
         />
       </div>

--- a/src/components/plant/PlantCard.tsx
+++ b/src/components/plant/PlantCard.tsx
@@ -3,8 +3,9 @@ import Link from 'next/link';
 
 interface Plant {
   id: string;
-  name: string;
-  species?: string | null;
+  nickname: string;
+  speciesScientific?: string | null;
+  speciesCommon?: string | null;
   imageUrl?: string | null;
 }
 
@@ -17,7 +18,7 @@ export default function PlantCard({ plant }: { plant: Plant }) {
       {plant.imageUrl ? (
         <Image
           src={plant.imageUrl}
-          alt={plant.name}
+          alt={plant.nickname}
           width={400}
           height={300}
           className="h-40 w-full object-cover"
@@ -26,9 +27,11 @@ export default function PlantCard({ plant }: { plant: Plant }) {
         <div className="h-40 w-full bg-muted" />
       )}
       <div className="p-2">
-        <h3 className="font-semibold">{plant.name}</h3>
-        {plant.species && (
-          <p className="text-sm text-muted-foreground">{plant.species}</p>
+        <h3 className="font-semibold">{plant.nickname}</h3>
+        {(plant.speciesScientific || plant.speciesCommon) && (
+          <p className="text-sm text-muted-foreground">
+            {plant.speciesScientific || plant.speciesCommon}
+          </p>
         )}
       </div>
     </Link>

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -25,7 +25,7 @@ export function generateWeeklyCareForecast(
           tasks.push({
             id: `${plant.id}-water-${dateStr}`,
             plantId: plant.id,
-            plantName: plant.name,
+            plantName: plant.nickname,
             type: 'water',
             due: nextWaterStr,
           });
@@ -40,7 +40,7 @@ export function generateWeeklyCareForecast(
           tasks.push({
             id: `${plant.id}-fertilize-${dateStr}`,
             plantId: plant.id,
-            plantName: plant.name,
+            plantName: plant.nickname,
             type: 'fertilize',
             due: nextFertStr,
           });

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -4,7 +4,7 @@ import type { CareEvent } from '@/types';
 
 export interface Plant {
   id: string;
-  name: string;
+  nickname: string;
   waterEvery?: string | null;
   fertEvery?: string | null;
   lastWateredAt?: string | null; // ISO date string
@@ -52,7 +52,7 @@ export function generateTasks(
         tasks.push({
           id: `${plant.id}-water`,
           plantId: plant.id,
-          plantName: plant.name,
+          plantName: plant.nickname,
           type: 'water',
           due: formatISO(due),
         });
@@ -66,7 +66,7 @@ export function generateTasks(
         tasks.push({
           id: `${plant.id}-fertilize`,
           plantId: plant.id,
-          plantName: plant.name,
+          plantName: plant.nickname,
           type: 'fertilize',
           due: formatISO(due),
         });

--- a/src/types/plant.ts
+++ b/src/types/plant.ts
@@ -1,6 +1,7 @@
 export type Plant = {
-  name: string;
-  species: string;
+  nickname: string;
+  speciesScientific: string;
+  speciesCommon?: string;
   potSize: string;
   potMaterial: string;
   lightLevel: string;

--- a/tests/forecast.test.ts
+++ b/tests/forecast.test.ts
@@ -5,7 +5,7 @@ import type { WeatherDay } from '../src/types/forecast';
 const plants = [
   {
     id: '1',
-    name: 'Monstera',
+    nickname: 'Monstera',
     waterEvery: '7 days',
     lastWateredAt: '2024-01-01',
   },

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -67,11 +67,11 @@ vi.mock("@/components/ui", () => ({ Button: ({ children }: { children: React.Rea
 vi.mock("@/lib/db", () => ({
   default: {
     plant: {
-      findUnique: () =>
+      findFirst: () =>
         Promise.resolve({
           id: "plant-1",
-          name: "My Plant",
-          species: "Pothos",
+          nickname: "My Plant",
+          speciesScientific: "Pothos",
           imageUrl: null,
           room: { name: "Living Room" },
         }),

--- a/tests/taskEngine.test.ts
+++ b/tests/taskEngine.test.ts
@@ -7,7 +7,7 @@ describe('generateTasks', () => {
     const plants = [
       {
         id: '1',
-        name: 'Monstera',
+        nickname: 'Monstera',
         waterEvery: '7 days',
         lastWateredAt: '2024-01-01',
       },
@@ -21,7 +21,7 @@ describe('generateTasks', () => {
     const plants = [
       {
         id: '1',
-        name: 'Monstera',
+        nickname: 'Monstera',
         waterEvery: '7 days',
         lastWateredAt: '2024-01-05',
       },
@@ -34,7 +34,7 @@ describe('generateTasks', () => {
     const plants = [
       {
         id: '1',
-        name: 'Monstera',
+        nickname: 'Monstera',
         waterEvery: '7 days',
         lastWateredAt: '2024-01-01',
       },
@@ -47,7 +47,7 @@ describe('generateTasks', () => {
     const plants = [
       {
         id: '1',
-        name: 'Fern',
+        nickname: 'Fern',
         fertEvery: '30 days',
         lastFertilizedAt: '2024-01-01',
       },
@@ -61,7 +61,7 @@ describe('generateTasks', () => {
     const plants = [
       {
         id: '1',
-        name: 'Rose',
+        nickname: 'Rose',
         waterEvery: '2 weeks',
         lastWateredAt: '2024-01-01',
       },


### PR DESCRIPTION
## Summary
- use UUID primary keys for plants and BigInt for room references
- rename plant fields to nickname/speciesScientific/speciesCommon
- update app, seed, and tests to new Prisma model

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` (fails: Failed to fetch the engine file)
- `pnpm test` (fails: expected 500 to be 200, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68acbc0d85048324883fc070de9c0885