### PR TITLE
feat: add snooze options for tasks

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -13,6 +13,12 @@ import {
 import Link from 'next/link';
 import type { Task } from '@/types/task';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import EmptyTasksState from '@/components/EmptyTasksState';
 
@@ -189,13 +195,24 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
         <Button onClick={triggerComplete} className="text-xs">
           Done
         </Button>
-        <Button
-          onClick={() => onSnooze(task.id)}
-          variant="secondary"
-          className="text-xs"
-        >
-          Snooze
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary" className="text-xs">
+              Snooze
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {[1, 3, 7].map((days) => (
+              <DropdownMenuItem
+                key={days}
+                onSelect={() => onSnooze(task.id, days)}
+                className="text-xs"
+              >
+                Snooze {days}d
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button asChild variant="outline" className="text-xs">
           <Link href={`/plants/${task.plantId}`}>View</Link>
         </Button>

--- a/tests/tasklist.test.tsx
+++ b/tests/tasklist.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import TaskList from "@/components/TaskList";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+describe("TaskList snooze menu", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends snooze request with chosen days", async () => {
+    const tasks = [
+      {
+        id: "1",
+        plantId: "1",
+        plantName: "Test Plant",
+        type: "water" as const,
+        due: new Date().toISOString(),
+      },
+    ];
+    render(<TaskList tasks={tasks} />);
+    const snoozeBtn = screen.getByText("Snooze");
+    fireEvent.keyDown(snoozeBtn, { key: 'Enter' });
+    const option = await screen.findByText("Snooze 3d");
+    fireEvent.click(option);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body).toEqual({ action: "snooze", days: 3 });
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add dropdown snooze options for 1, 3, or 7 days on task list
- test snooze menu sends correct API request

## Testing
- `pnpm test tests/tasklist.test.tsx`
- `pnpm lint src/components/TaskList.tsx tests/tasklist.test.tsx`
- `pnpm test` *(fails: /api routes return 500, events api returns 400, tasks api etc)*

------
https://chatgpt.com/codex/tasks/task_e_68acbf19571c8324a21096b7e1d693f0