### PR TITLE
docs: reference events migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ All schema, policies, and seed data live as SQL in [`/supabase`](./supabase).
 
 - `plants.sql` – plants and species tables with RLS policies
 - `tasks.sql` – care task table and policies
-- `migrations/20250825045101_rooms_events.sql` – rooms and events tables with RLS policies
+- `supabase/migrations/20250825045101_rooms_events.sql` – rooms and events tables with RLS policies
 - `analytics.sql` – analytics events table
 - `sample_data.sql` – optional seed data for plants and tasks
 
@@ -121,7 +121,7 @@ pnpm db:seed
 pnpm dev
 ```
 
-`supabase/plants.sql` can be re-run safely to add or rename columns. After executing any SQL files, refresh the Supabase API schema with `select pg_notify('pgrst','reload schema');` or restart the API.
+`supabase/plants.sql` can be re-run safely to add or rename columns. After executing any SQL files, Supabase's schema cache must be refreshed with `select pg_notify('pgrst','reload schema');` or by restarting the API.
 
 See `/docs/deployment.md` for full production deployment steps.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ Schema, policies, and seed data are stored as raw SQL in `/supabase`:
 
 - `plants.sql` – plants and species tables with RLS policies
 - `tasks.sql` – care task table and policies
-- `events.sql` – user event log
+- `supabase/migrations/20250825045101_rooms_events.sql` – rooms and events tables with RLS policies
 - `analytics.sql` – analytics events table
 - `sample_data.sql` – optional seed data for plants and tasks
 
@@ -39,8 +39,10 @@ Apply the SQL with the Supabase CLI:
 ```bash
 supabase db execute supabase/plants.sql
 supabase db execute supabase/tasks.sql
-supabase db execute supabase/events.sql
+supabase db execute supabase/migrations/20250825045101_rooms_events.sql
 supabase db execute supabase/analytics.sql
 supabase db execute supabase/sample_data.sql # optional seed data
 ```
+
+After executing the SQL files, Supabase's schema cache must be refreshed with `select pg_notify('pgrst','reload schema');` or by restarting the API.
 


### PR DESCRIPTION
## Summary
- point README to the `supabase/migrations/20250825045101_rooms_events.sql` migration instead of `events.sql`
- note that Supabase's schema cache must be refreshed after applying SQL files
- document the migration path in the architecture notes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 10 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0f838108324b43e913bdd9f40ed