### PR TITLE
Add error handling for plant timeline

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -205,6 +205,7 @@ Reuses Plant Detail timeline snippet above.
 ---
 
 ## 9. Error & Empty-State Handling
+- [x] Display an error message when plant timeline fails to load
 See empty state example in section 0.
 
 ---

--- a/src/components/plant/Timeline.tsx
+++ b/src/components/plant/Timeline.tsx
@@ -12,13 +12,22 @@ type Event = {
 export function Timeline({ plantId }: { plantId: number }) {
   const [items, setItems] = React.useState<Event[]>([]);
   const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
 
   async function load() {
     setLoading(true);
-    const res = await fetch(`/api/events?plantId=${plantId}`);
-    const data = await res.json();
-    setItems(Array.isArray(data) ? data : []);
-    setLoading(false);
+    setError(null);
+    try {
+      const res = await fetch(`/api/events?plantId=${plantId}`);
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json();
+      setItems(Array.isArray(data) ? data : []);
+    } catch {
+      setError("Failed to load events");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
   }
 
   React.useEffect(() => {
@@ -30,6 +39,7 @@ export function Timeline({ plantId }: { plantId: number }) {
   }, [plantId]);
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading timeline…</p>;
+  if (error) return <p className="text-sm text-destructive">{error}</p>;
   if (items.length === 0) return <p className="text-sm text-muted-foreground">No events yet.</p>;
 
   return (

--- a/tests/timeline.test.tsx
+++ b/tests/timeline.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Timeline } from "@/components/plant/Timeline";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+describe("Timeline", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+  it("shows error message when fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: false, json: async () => ({}) })));
+    render(<Timeline plantId={1} />);
+    const msg = await screen.findByText("Failed to load events");
+    expect(msg).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- show an error message when plant timeline events fail to load
- record completion of error handling in implementation tasks doc
- add test for timeline error state

## Testing
- `npm test` *(fails: AssertionError expected 200 to be 500 etc)*
- `npx vitest run tests/timeline.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acc07cce948324878e4b4d756c523b