### PR TITLE
Handle timeline load errors

### DIFF
--- a/src/components/CareTimeline.tsx
+++ b/src/components/CareTimeline.tsx
@@ -4,7 +4,19 @@ import Image from 'next/image';
 import { format } from 'date-fns';
 import type { CareEvent } from '@/types';
 
-export default function CareTimeline({ events }: { events: CareEvent[] }) {
+export default function CareTimeline({
+  events,
+  error = false,
+}: {
+  events: CareEvent[];
+  error?: boolean;
+}) {
+  if (error) {
+    return (
+      <p className="text-sm text-destructive">Failed to load timeline.</p>
+    );
+  }
+
   if (!events || events.length === 0) {
     return <p className="text-sm text-muted-foreground">No care events yet.</p>;
   }

--- a/src/components/plant/PlantTabs.tsx
+++ b/src/components/plant/PlantTabs.tsx
@@ -11,9 +11,14 @@ import PhotoGalleryClient from './PhotoGalleryClient';
 interface PlantTabsProps {
   plantId: string;
   initialEvents: CareEvent[];
+  timelineError?: boolean;
 }
 
-export default function PlantTabs({ plantId, initialEvents }: PlantTabsProps) {
+export default function PlantTabs({
+  plantId,
+  initialEvents,
+  timelineError = false,
+}: PlantTabsProps) {
   const [events, setEvents] = useState<CareEvent[]>(initialEvents);
 
   useEffect(() => {
@@ -39,7 +44,7 @@ export default function PlantTabs({ plantId, initialEvents }: PlantTabsProps) {
         <TabsTrigger value="notes">Notes</TabsTrigger>
       </TabsList>
       <TabsContent value="timeline" className="mt-6">
-        <CareTimeline events={events} />
+        <CareTimeline events={events} error={timelineError} />
       </TabsContent>
       <TabsContent value="care" className="mt-6">
         <p className="text-sm text-muted-foreground">Care plan coming soon.</p>

--- a/tests/caretimeline.test.tsx
+++ b/tests/caretimeline.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import CareTimeline from "@/components/CareTimeline";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+describe("CareTimeline", () => {
+  it("shows error message when error is true", () => {
+    render(<CareTimeline events={[]} error />);
+    expect(screen.getByText("Failed to load timeline.")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- surface a clear message when plant timeline events fail to load
- plumb error flag through PlantTabs to CareTimeline
- add unit test for CareTimeline error state

## Testing
- `pnpm lint`
- `pnpm test` *(fails: "AssertionError: expected 500 to be 200" in multiple API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acc40153348324a87f9c7f9ba0c164