### PR TITLE
feat: add retry to timeline error

### DIFF
--- a/src/components/CareTimeline.tsx
+++ b/src/components/CareTimeline.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { format } from 'date-fns';
+import { Button } from '@/components/ui/button';
 import type { CareEvent } from '@/types';
 
 export default function CareTimeline({
@@ -13,7 +14,16 @@ export default function CareTimeline({
 }) {
   if (error) {
     return (
-      <p className="text-sm text-destructive">Failed to load timeline.</p>
+      <div className="flex items-center gap-2 text-sm text-destructive">
+        <span>Failed to load timeline.</span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => window.location.reload()}
+        >
+          Retry
+        </Button>
+      </div>
     );
   }
 

--- a/tests/caretimeline.test.tsx
+++ b/tests/caretimeline.test.tsx
@@ -9,5 +9,6 @@ describe("CareTimeline", () => {
   it("shows error message when error is true", () => {
     render(<CareTimeline events={[]} error />);
     expect(screen.getByText("Failed to load timeline.")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- add retry button when plant timeline fails to load
- test for retry button presence in CareTimeline

## Testing
- `pnpm test` *(fails: expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_68acc597416883249592d13139aad79b