### PR TITLE
Add quick event logging to timeline

### DIFF
--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -2,13 +2,13 @@
 
 import * as React from "react";
 
-type Props = { plantId: number };
+type Props = { plantId: string };
 
 export function EventQuickAdd({ plantId }: Props) {
   const [note, setNote] = React.useState("");
 
-  async function add(type: "watered" | "fertilized" | "note") {
-    const payload: Record<string, unknown> = { plantId, type };
+  async function add(type: "water" | "fertilize" | "note") {
+    const payload: Record<string, unknown> = { plant_id: plantId, type };
     if (type === "note" && note.trim()) payload.note = note.trim();
 
     const res = await fetch("/api/events", {
@@ -19,15 +19,29 @@ export function EventQuickAdd({ plantId }: Props) {
     if (res.ok) {
       setNote("");
       // Consumers should refetch timeline; emit custom event
-      window.dispatchEvent(new CustomEvent("flora:events:changed", { detail: { plantId } }));
+      window.dispatchEvent(
+        new CustomEvent("flora:events:changed", { detail: { plantId } }),
+      );
     }
   }
 
   return (
     <div className="rounded-xl border bg-card p-4 space-y-3">
       <div className="flex gap-2">
-        <button type="button" onClick={() => add("watered")} className="h-9 rounded-md bg-primary px-3 text-sm text-primary-foreground">Watered</button>
-        <button type="button" onClick={() => add("fertilized")} className="h-9 rounded-md border px-3 text-sm">Fertilized</button>
+        <button
+          type="button"
+          onClick={() => add("water")}
+          className="h-9 rounded-md bg-primary px-3 text-sm text-primary-foreground"
+        >
+          Watered
+        </button>
+        <button
+          type="button"
+          onClick={() => add("fertilize")}
+          className="h-9 rounded-md border px-3 text-sm"
+        >
+          Fertilized
+        </button>
       </div>
       <div className="flex gap-2">
         <input
@@ -36,7 +50,13 @@ export function EventQuickAdd({ plantId }: Props) {
           value={note}
           onChange={(e) => setNote(e.target.value)}
         />
-        <button type="button" onClick={() => add("note")} className="h-9 rounded-md border px-3 text-sm">Add note</button>
+        <button
+          type="button"
+          onClick={() => add("note")}
+          className="h-9 rounded-md border px-3 text-sm"
+        >
+          Add note
+        </button>
       </div>
     </div>
   );

--- a/src/components/plant/PlantTabs.tsx
+++ b/src/components/plant/PlantTabs.tsx
@@ -7,6 +7,7 @@ import CareTimeline from '@/components/CareTimeline';
 import AddNoteForm from '@/components/AddNoteForm';
 import AddPhotoForm from '@/components/AddPhotoForm';
 import PhotoGalleryClient from './PhotoGalleryClient';
+import { EventQuickAdd } from './EventQuickAdd';
 
 interface PlantTabsProps {
   plantId: string;
@@ -43,7 +44,8 @@ export default function PlantTabs({
         <TabsTrigger value="photos">Photos</TabsTrigger>
         <TabsTrigger value="notes">Notes</TabsTrigger>
       </TabsList>
-      <TabsContent value="timeline" className="mt-6">
+      <TabsContent value="timeline" className="mt-6 space-y-4">
+        <EventQuickAdd plantId={plantId} />
         <CareTimeline events={events} error={timelineError} />
       </TabsContent>
       <TabsContent value="care" className="mt-6">

--- a/tests/eventquickadd.test.tsx
+++ b/tests/eventquickadd.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EventQuickAdd } from '../src/components/plant/EventQuickAdd';
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+describe('EventQuickAdd', () => {
+  it('posts water event with plant_id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const spy = vi.spyOn(global, 'fetch').mockImplementation(fetchMock as any);
+    const dispatchMock = vi.fn();
+    window.dispatchEvent = dispatchMock as any;
+
+    render(<EventQuickAdd plantId="123" />);
+    await fireEvent.click(screen.getByText('Watered'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/events',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ plant_id: '123', type: 'water' }),
+        }),
+      );
+    });
+    expect(dispatchMock).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('sends note text when adding note', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const spy = vi.spyOn(global, 'fetch').mockImplementation(fetchMock as any);
+
+    render(<EventQuickAdd plantId="123" />);
+    fireEvent.change(screen.getByPlaceholderText('Quick note…'), {
+      target: { value: 'hello' },
+    });
+    await fireEvent.click(screen.getByText('Add note'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/events',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ plant_id: '123', type: 'note', note: 'hello' }),
+        }),
+      );
+    });
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- fix EventQuickAdd payload and support water/fertilize/note logging
- show quick event buttons on plant timeline tab
- test event quick add interactions

## Testing
- `pnpm test` *(fails: plants.api.test.ts and others returning status 500/400)*

------
https://chatgpt.com/codex/tasks/task_e_68accb4360fc832490eb32bb813bc600