### PR TITLE
fix: enable Tailwind PostCSS plugin

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
+import tailwindcss from '@tailwindcss/postcss'
 
-export default config;
+const config = {
+  plugins: [tailwindcss],
+}
+
+export default config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss"
+import animate from "tailwindcss-animate"
 
 export default {
   darkMode: ["class"],
@@ -43,5 +44,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config


### PR DESCRIPTION
## Summary
- load Tailwind via PostCSS plugin for CSS processing
- switch Tailwind animate plugin to ESM import to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test` *(fails: /api plants and others return 500/400)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8b9c5008324a10e49032b8b1186