### PR TITLE
fix lightningcss resolution in turbopack build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,9 @@ import type { NextConfig } from "next";
 import "./src/lib/config";
 
 const nextConfig: NextConfig = {
+  // Ensure native modules from lightningcss are resolved at runtime
+  // by externalizing it and its wrapper package
+  serverExternalPackages: ["lightningcss", "@tailwindcss/node"],
   /* config options here */
 };
 


### PR DESCRIPTION
## Summary
- externalize lightningcss and wrapper package so Turbopack resolves native module at runtime

## Testing
- `npm run build` *(fails: TurbopackInternalError: Failed to write page endpoint /_error)*

------
https://chatgpt.com/codex/tasks/task_e_68aced4bb7d083249d9aa15b555d2392