### PR TITLE
feat: add tasks API endpoint

### DIFF
--- a/scripts/send-reminders.ts
+++ b/scripts/send-reminders.ts
@@ -4,8 +4,24 @@
  */
 async function main() {
   const now = new Date().toISOString()
-  // TODO: fetch due/overdue tasks by querying your /api/tasks once implemented
-  const tasks = [{ to: "test@example.com", subject: "Flora — Daily digest", body: "You have 2 tasks due today." }]
+  const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+  let dueCount = 0
+  try {
+    const res = await fetch(`${base}/api/tasks?days=1`)
+    if (res.ok) {
+      const json = await res.json()
+      dueCount = Array.isArray(json.tasks) ? json.tasks.length : 0
+    }
+  } catch {
+    // ignore errors and fall back to zero
+  }
+  const tasks = [
+    {
+      to: "test@example.com",
+      subject: "Flora — Daily digest",
+      body: `You have ${dueCount} task${dueCount === 1 ? "" : "s"} due today.`,
+    },
+  ]
   for (const t of tasks) {
     // eslint-disable-next-line no-console
     console.log(`[${now}] Would send email to ${t.to}: ${t.subject} -> ${t.body}`)

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { addDays, formatISO } from "date-fns";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getCurrentUserId } from "@/lib/auth";
+
+export async function GET(req: Request) {
+  try {
+    const userId = await getCurrentUserId();
+    const url = new URL(req.url);
+    const days = parseInt(url.searchParams.get("days") || "7", 10);
+    const end = formatISO(addDays(new Date(), days), { representation: "date" });
+
+    const { data: tasks, error: tErr } = await supabaseAdmin
+      .from("tasks")
+      .select("id, plant_id, type, due_date, completed_at")
+      .eq("user_id", userId)
+      .lte("due_date", end)
+      .is("completed_at", null)
+      .order("due_date", { ascending: true });
+    if (tErr) throw tErr;
+
+    const { data: plants, error: pErr } = await supabaseAdmin
+      .from("plants")
+      .select("id, nickname")
+      .eq("user_id", userId);
+    if (pErr) throw pErr;
+
+    const plantMap = new Map<string, string>();
+    for (const p of plants || []) {
+      plantMap.set(p.id as string, (p as any).nickname as string);
+    }
+
+    const result = (tasks || []).map((t) => ({
+      id: t.id as string,
+      plantId: t.plant_id as string,
+      plantName: plantMap.get(t.plant_id as string) || "Unknown",
+      type: t.type as string,
+      due: t.due_date as string,
+    }));
+
+    return NextResponse.json({ tasks: result }, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const msg = err instanceof Error ? err.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export const runtime = "edge";

--- a/tests/tasks-list.api.test.ts
+++ b/tests/tasks-list.api.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => Promise.resolve("user-123"),
+}));
+
+const tasksData = [
+  { id: "1", plant_id: "p1", type: "water", due_date: "2024-01-01", completed_at: null },
+  { id: "2", plant_id: "p2", type: "fertilize", due_date: "2024-01-02", completed_at: "2024-01-01" },
+];
+const plantsData = [
+  { id: "p1", nickname: "Aloe" },
+  { id: "p2", nickname: "Snake" },
+];
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "tasks") {
+        return {
+          select: () => ({
+            eq: () => ({
+              lte: () => ({
+                is: () => ({
+                  order: () =>
+                    Promise.resolve({
+                      data: tasksData.filter((t) => t.completed_at === null),
+                      error: null,
+                    }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "plants") {
+        return {
+          select: () => ({
+            eq: () => Promise.resolve({ data: plantsData, error: null }),
+          }),
+        };
+      }
+      return {} as Record<string, never>;
+    },
+  }),
+}));
+
+describe("GET /api/tasks", () => {
+  beforeEach(() => {
+    // reset if needed
+  });
+
+  it("returns pending tasks with plant names", async () => {
+    const { GET } = await import("../src/app/api/tasks/route");
+    const req = new Request("http://localhost/api/tasks");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tasks).toHaveLength(1);
+    expect(json.tasks[0]).toEqual({
+      id: "1",
+      plantId: "p1",
+      plantName: "Aloe",
+      type: "water",
+      due: "2024-01-01",
+    });
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- expose `/api/tasks` to list upcoming tasks for the current user
- fetch task counts in reminder script to build daily digest
- add unit test for tasks API

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 200 to be 500, etc.)*
- `pnpm test tests/tasks-list.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68acef5c6c488324a84d321a975651a1