### PR TITLE
Handle Care Coach suggestion fetch errors

### DIFF
--- a/src/components/plant/CareCoach.tsx
+++ b/src/components/plant/CareCoach.tsx
@@ -9,17 +9,26 @@ interface CareCoachProps {
 }
 
 export default async function CareCoach({ plant }: CareCoachProps) {
-
-  const suggestions = await getAiCareSuggestions(plant.id);
+  let suggestions: string[] = [];
+  let error = false;
+  try {
+    suggestions = await getAiCareSuggestions(plant.id);
+  } catch {
+    error = true;
+  }
 
   return (
     <div className="mt-4 rounded border bg-muted/50 p-4">
       <h2 className="mb-2 text-lg font-semibold">Care Coach</h2>
-      <ul className="list-disc pl-5 text-sm">
-        {suggestions.map((s, i) => (
-          <li key={i}>{s}</li>
-        ))}
-      </ul>
+      {error ? (
+        <p className="text-sm text-destructive">Failed to load suggestions.</p>
+      ) : (
+        <ul className="list-disc pl-5 text-sm">
+          {suggestions.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/tests/carecoach.test.tsx
+++ b/tests/carecoach.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect, vi, type Mock } from "vitest";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock("@/lib/aiCare", () => ({
+  getAiCareSuggestions: vi.fn(),
+}));
+
+describe("CareCoach", () => {
+  it("shows error message when suggestions fail", async () => {
+    const { getAiCareSuggestions } = await import("@/lib/aiCare");
+    (getAiCareSuggestions as Mock).mockRejectedValue(new Error("fail"));
+    const CareCoach = (await import("../src/components/plant/CareCoach")).default;
+    const element = await CareCoach({ plant: { id: "1" } });
+    const html = renderToString(element);
+    expect(html).toContain("Failed to load suggestions");
+  });
+});
+


### PR DESCRIPTION
## Summary
- Handle failures when fetching AI care suggestions by showing a descriptive error in Care Coach
- Test Care Coach error handling

## Testing
- `pnpm test` *(fails: plants.api.test.ts, events.api.test.ts, tasks.api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68acf0e11850832492222843ad22a916