### PR TITLE
Handle timeline fetch failures

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -46,8 +46,12 @@ export default async function PlantDetailPage({
       .eq("plant_id", plant.id)
       .eq("user_id", userId)
       .order("created_at", { ascending: false });
-    if (error) timelineError = true;
+    if (error) {
+      timelineError = true;
+    }
     events = data ?? [];
+  } else {
+    timelineError = true;
   }
 
   const timelineEvents = hydrateTimeline(events, {


### PR DESCRIPTION
## Summary
- mark plant timeline as errored if Supabase query fails or client missing
- test that PlantTabs receives a timelineError flag when event fetch fails

## Testing
- `npm test` *(fails: expected API status codes vs. 500 responses)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf254e158832493163eaefbcc82b1