### PR TITLE
Disable quick-add actions during post

### DIFF
--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -12,11 +12,14 @@ interface Props {
 
 export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
   const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (saving) return;
     const trimmed = note.trim();
     if (!trimmed) return;
+    setSaving(true);
     const tempId = `temp-${Date.now()}`;
     const optimistic: CareEvent = {
       id: tempId,
@@ -42,6 +45,8 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
       }
     } catch (err) {
       console.error('Failed to add note', err);
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -53,7 +58,7 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
-      <Button type="submit" className="p-4">
+      <Button type="submit" className="p-4" disabled={saving}>
         Add Note
       </Button>
     </form>

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -18,10 +18,12 @@ interface Props {
 
 export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!file) return;
+    if (!file || saving) return;
+    setSaving(true);
     const tempId = `temp-${Date.now()}`;
     const optimistic: CareEvent = {
       id: tempId,
@@ -51,6 +53,8 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
       }
     } catch (err) {
       console.error('Failed to upload photo', err);
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -59,12 +63,13 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
       <input
         type="file"
         accept="image/*"
+        disabled={saving}
         onChange={(e) => setFile(e.target.files?.[0] ?? null)}
       />
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button type="submit" className="p-4">
+            <Button type="submit" className="p-4" disabled={saving}>
               Upload Photo
             </Button>
           </TooltipTrigger>

--- a/tests/addnoteform.test.tsx
+++ b/tests/addnoteform.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderToString } from "react-dom/server";
+import { render, screen, fireEvent } from "@testing-library/react";
 import AddNoteForm from "../src/components/AddNoteForm";
 
 (globalThis as unknown as { React: typeof React }).React = React;
@@ -10,11 +11,37 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("AddNoteForm", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("renders textarea and button", () => {
     const html = renderToString(
       <AddNoteForm plantId="1" onAdd={() => undefined} onReplace={() => undefined} />,
     );
     expect(html).toContain("textarea");
     expect(html).toContain("Add Note");
+  });
+
+  it("disables submit while posting", () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise((res) => {
+            resolveFetch = res;
+          }),
+      ),
+    );
+    render(<AddNoteForm plantId="1" onAdd={() => undefined} onReplace={() => undefined} />);
+    const textarea = screen.getByPlaceholderText("Write a note...");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    const button = screen.getByRole("button", { name: /add note/i });
+    fireEvent.click(button);
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect((globalThis.fetch as any)).toHaveBeenCalledTimes(1);
+    resolveFetch({ ok: true, json: () => Promise.resolve({}) });
   });
 });

--- a/tests/tasklist.test.tsx
+++ b/tests/tasklist.test.tsx
@@ -5,6 +5,11 @@ import TaskList from "@/components/TaskList";
 
 (globalThis as unknown as { React: typeof React }).React = React;
 
+vi.mock("canvas-confetti", () => ({
+  __esModule: true,
+  default: () => {},
+}));
+
 describe("TaskList snooze menu", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -16,6 +21,26 @@ describe("TaskList snooze menu", () => {
           json: () => Promise.resolve({}),
         })
       )
+    );
+    vi.stubGlobal(
+      "AudioContext",
+      vi.fn(() => ({
+        createOscillator: () => ({
+          type: "sine",
+          frequency: { setValueAtTime: () => {} },
+          connect: () => {},
+          start: () => {},
+          stop: () => {},
+          onended: null,
+        }),
+        createGain: () => ({
+          gain: { setValueAtTime: () => {}, exponentialRampToValueAtTime: () => {} },
+          connect: () => {},
+        }),
+        destination: {},
+        currentTime: 0,
+        close: () => {},
+      }))
     );
   });
 
@@ -41,6 +66,33 @@ describe("TaskList snooze menu", () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
     expect(body).toEqual({ action: "snooze", days: 3 });
+  });
+
+  it("prevents duplicate completion requests", () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((res) => {
+          resolveFetch = res;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const tasks = [
+      {
+        id: "1",
+        plantId: "1",
+        plantName: "Test Plant",
+        type: "water" as const,
+        due: new Date().toISOString(),
+      },
+    ];
+    render(<TaskList tasks={tasks} />);
+    const doneBtn = screen.getByText("Done");
+    fireEvent.click(doneBtn);
+    expect(doneBtn).toBeDisabled();
+    fireEvent.click(doneBtn);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFetch({ ok: true, json: () => Promise.resolve({}) });
   });
 });
 


### PR DESCRIPTION
## Summary
- disable TaskList quick actions while requests are pending
- prevent duplicate submissions in AddNoteForm and AddPhotoForm
- add tests for quick-add button disabling

## Testing
- `pnpm test tests/tasklist.test.tsx tests/addnoteform.test.tsx`
- `pnpm test` *(fails: e.g., plants.api.test.ts expected 200 to be 500; events.api.test.ts expected 200 to be 400)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4245b588324aafce19b38f3f534