### PR TITLE
fix: make lightningcss native module resolvable

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/cli": "^4.1.12",
+    "@tailwindcss/node": "^4.1.12",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
@@ -67,6 +68,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
     "jsdom": "^26.1.0",
+    "lightningcss": "^1.30.1",
     "prisma": "^6.14.0",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@tailwindcss/cli':
         specifier: ^4.1.12
         version: 4.1.12
+      '@tailwindcss/node':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.12
@@ -162,6 +165,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      lightningcss:
+        specifier: ^1.30.1
+        version: 1.30.1
       prisma:
         specifier: ^6.14.0
         version: 6.14.0(magicast@0.3.5)(typescript@5.9.2)


### PR DESCRIPTION
## Summary
- add @tailwindcss/node and lightningcss as dev dependencies so the runtime can resolve lightningcss's native bindings
- rely on Next.js `serverExternalPackages` to load these modules instead of bundling

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to write page endpoint /_error)*
- `pnpm test` *(fails: tests rely on API endpoints returning 200 but received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4f4a6e08324abcf47fe666a0b1b