### PR TITLE
fix: avoid lightningcss module resolution error

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,5 @@
+const tailwindcss = require('@tailwindcss/postcss');
+
+module.exports = {
+  plugins: [tailwindcss],
+};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,0 @@
-import tailwindcss from '@tailwindcss/postcss'
-
-const config = {
-  plugins: [tailwindcss],
-}
-
-export default config


### PR DESCRIPTION
## Summary
- convert PostCSS config to CommonJS so Tailwind's LightningCSS integration resolves at runtime

## Testing
- `pnpm build` *(fails: TurbopackInternalError: Failed to write page endpoint /_error)*
- `pnpm test` *(fails: AssertionError: expected 500 to be 200 // Object.is equality)*

------
https://chatgpt.com/codex/tasks/task_e_68acf70b07148324856bcb24331a3442