### PR TITLE
Fix plant and event API routes

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { addDays, formatISO } from "date-fns";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
@@ -8,7 +7,8 @@ export async function GET(req: Request) {
     const userId = await getCurrentUserId();
     const url = new URL(req.url);
     const days = parseInt(url.searchParams.get("days") || "7", 10);
-    const end = formatISO(addDays(new Date(), days), { representation: "date" });
+    const endDate = new Date(Date.now() + days * 86400000);
+    const end = endDate.toISOString().slice(0, 10);
 
     const { data: tasks, error: tErr } = await supabaseAdmin
       .from("tasks")
@@ -48,4 +48,3 @@ export async function GET(req: Request) {
   }
 }
 
-export const runtime = "edge";


### PR DESCRIPTION
## Summary
- handle snake_case plant IDs and user attribution in event API
- support flexible Supabase responses for plant CRUD endpoints
- simplify tasks listing endpoint and manual date handling

## Testing
- `pnpm vitest run tests/plants.api.test.ts __tests__/plants.api.test.ts tests/events.api.test.ts tests/tasks-list.api.test.ts`
- `pnpm vitest run tests/tasks.api.test.ts` *(fails: marks a task as complete and logs the event, snoozes a task...)*
- `pnpm vitest run tests/plant.page.test.tsx` *(fails: falls back to latest photo when plant has no main image)*

------
https://chatgpt.com/codex/tasks/task_e_68acf61a382483248ecc17a166529d26