### PR TITLE
feat: add reminder cron job

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -71,7 +71,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 5. Notifications & Reminders
-- [ ] Background job to check due/overdue tasks
+- [x] Background job to check due/overdue tasks
 - [ ] Email or push notifications with deep links
 - [ ] User controls for quiet hours and per-plant mute
 

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const tailwindcss = require('@tailwindcss/postcss');
 
 module.exports = {

--- a/src/app/api/notifications/cron/route.ts
+++ b/src/app/api/notifications/cron/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+// Scheduled endpoint to check for due and overdue tasks.
+export async function GET() {
+  const today = new Date().toISOString().slice(0, 10);
+  try {
+    const { data: tasks, error } = await supabaseAdmin
+      .from("tasks")
+      .select("id, due_date")
+      .lte("due_date", today)
+      .is("completed_at", null);
+    if (error) throw error;
+
+    let due = 0;
+    let overdue = 0;
+    for (const t of tasks || []) {
+      const dueDate = t.due_date as string;
+      if (dueDate === today) due++;
+      else overdue++;
+    }
+
+    console.log(
+      `[${new Date().toISOString()}] Checked tasks: ${overdue} overdue, ${due} due.`
+    );
+
+    return NextResponse.json({ ok: true, overdue, due });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Server error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+

--- a/tests/notifications.cron.api.test.ts
+++ b/tests/notifications.cron.api.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const today = new Date().toISOString().slice(0, 10);
+const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        lte: () => ({
+          is: () =>
+            Promise.resolve({
+              data: [
+                { id: "1", plant_id: "p1", type: "water", due_date: today },
+                { id: "2", plant_id: "p2", type: "fertilize", due_date: yesterday },
+              ],
+              error: null,
+            }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+describe("GET /api/notifications/cron", () => {
+  it("counts due and overdue tasks", async () => {
+    const { GET } = await import("../src/app/api/notifications/cron/route");
+    const req = new Request("http://localhost/api/notifications/cron");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, overdue: 1, due: 1 });
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- add /api/notifications/cron endpoint to tally due and overdue tasks
- document completion of background job
- silence require import lint warning in PostCSS config

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfa019f348324b1b54750cfa9cfc3