### PR TITLE
feat: add shadcn task card component

### DIFF
--- a/docs/design-tasks.md
+++ b/docs/design-tasks.md
@@ -145,7 +145,7 @@ export function PlantHero() {
 
 ## 4. Today View (Tasks)
 
-- [ ] **Task Card**
+- [x] **Task Card**
   - Base on shadcn/ui `<Card>`
   - Avatar left, task title/desc middle, button right
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@hookform/resolvers": "5.2.1",
     "@prisma/client": "^6.14.0",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@prisma/client':
         specifier: ^6.14.0
         version: 6.14.0(prisma@6.14.0(magicast@0.3.5)(typescript@5.9.2))(typescript@5.9.2)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -901,6 +904,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
@@ -1296,6 +1312,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4038,6 +4063,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -4779,6 +4809,19 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.10)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5218,6 +5261,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.0)
       react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.10
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.10)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.10
 
@@ -8421,6 +8471,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.10
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const tailwindcss = require('@tailwindcss/postcss');
 
 module.exports = {

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import Link from "next/link"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu"
+import type { Task } from "@/types/task"
+
+interface TaskCardProps {
+  task: Task
+  onComplete: () => void
+  onSnooze: (days: number) => void
+  pending?: boolean
+}
+
+export default function TaskCard({
+  task,
+  onComplete,
+  onSnooze,
+  pending = false,
+}: TaskCardProps) {
+  return (
+    <Card className="flex items-center gap-3 px-3 py-3">
+      <Avatar>
+        <AvatarFallback>🌱</AvatarFallback>
+      </Avatar>
+      <CardContent className="flex-1 min-w-0 p-0">
+        <div className="text-sm font-medium">{task.plantName}</div>
+        <div className="text-xs text-muted-foreground capitalize">{task.type}</div>
+      </CardContent>
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={onComplete} disabled={pending}>
+          Done
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="sm" variant="secondary" disabled={pending}>
+              Snooze
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {[1, 3, 7].map((days) => (
+              <DropdownMenuItem
+                key={days}
+                onSelect={() => onSnooze(days)}
+                className="text-xs"
+              >
+                Snooze {days}d
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/plants/${task.plantId}`}>View</Link>
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -10,15 +10,8 @@ import {
   parseISO,
   startOfDay,
 } from 'date-fns';
-import Link from 'next/link';
 import type { Task } from '@/types/task';
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/dropdown-menu';
+import TaskCard from '@/components/TaskCard';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import EmptyTasksState from '@/components/EmptyTasksState';
 
@@ -191,7 +184,6 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, x: 100 }}
       transition={{ duration: 0.2 }}
-      className="rounded-xl border py-4 px-4 sm:px-6 md:px-8"
       style={{
         transform: `translateX(${offsetX}px)`,
         touchAction: 'pan-y',
@@ -202,34 +194,12 @@ function TaskItem({ task, onComplete, onSnooze }: TaskItemProps) {
       onPointerLeave={startX !== null ? handlePointerEnd : undefined}
       onPointerCancel={handlePointerEnd}
     >
-      <p className="font-medium animate-pulse-weight">{task.plantName}</p>
-      <p className="text-sm text-muted-foreground capitalize">{task.type}</p>
-      <div className="mt-2 flex gap-3 sm:gap-4 md:gap-6">
-        <Button onClick={triggerComplete} className="text-xs" disabled={pending}>
-          Done
-        </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary" className="text-xs" disabled={pending}>
-              Snooze
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {[1, 3, 7].map((days) => (
-              <DropdownMenuItem
-                key={days}
-                onSelect={() => handleSnoozeSelect(days)}
-                className="text-xs"
-              >
-                Snooze {days}d
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <Button asChild variant="outline" className="text-xs">
-          <Link href={`/plants/${task.plantId}`}>View</Link>
-        </Button>
-      </div>
+      <TaskCard
+        task={task}
+        onComplete={triggerComplete}
+        onSnooze={handleSnoozeSelect}
+        pending={pending}
+      />
     </motion.li>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as TaskList } from './TaskList';
 export { default as Navigation } from './Navigation';
 export { default as EmptyPlantState } from './EmptyPlantState';
 export { default as EmptyTasksState } from './EmptyTasksState';
+export { default as TaskCard } from './TaskCard';

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }


### PR DESCRIPTION
## Summary
- add shadcn-based TaskCard and Avatar components
- integrate TaskCard into TaskList and mark design task complete
- include @radix-ui/react-avatar dependency and lint config tweak

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfa3461648324a57a3200c252b1bd