### PR TITLE
feat: add notification deep links

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -72,7 +72,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ## 5. Notifications & Reminders
 - [x] Background job to check due/overdue tasks
-- [ ] Email or push notifications with deep links
+- [x] Email or push notifications with deep links
 - [ ] User controls for quiet hours and per-plant mute
 
 ---

--- a/scripts/send-reminders.ts
+++ b/scripts/send-reminders.ts
@@ -4,7 +4,7 @@
  */
 async function main() {
   const now = new Date().toISOString()
-  const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+  const base = (process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000").replace(/\/$/, "")
   let dueCount = 0
   try {
     const res = await fetch(`${base}/api/tasks?days=1`)
@@ -15,16 +15,20 @@ async function main() {
   } catch {
     // ignore errors and fall back to zero
   }
+  const deepLink = `${base}/today`
   const tasks = [
     {
       to: "test@example.com",
       subject: "Flora — Daily digest",
       body: `You have ${dueCount} task${dueCount === 1 ? "" : "s"} due today.`,
+      deepLink,
     },
   ]
   for (const t of tasks) {
     // eslint-disable-next-line no-console
-    console.log(`[${now}] Would send email to ${t.to}: ${t.subject} -> ${t.body}`)
+    console.log(
+      `[${now}] Would send email to ${t.to}: ${t.subject} -> ${t.body} (${t.deepLink})`
+    )
   }
 }
 main().catch((e) => {

--- a/src/app/api/notifications/test/route.ts
+++ b/src/app/api/notifications/test/route.ts
@@ -3,12 +3,13 @@ import { NextResponse } from "next/server"
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const to = url.searchParams.get("to") || "test@example.com"
+  const base = (process.env.NEXT_PUBLIC_BASE_URL || "").replace(/\/$/, "")
   // Simulated payload
   const payload = {
     to,
     subject: "Flora — You have tasks due today",
     body: "Open Flora and check your Today list.",
-    deepLink: "/today"
+    deepLink: `${base}/today`,
   }
   return NextResponse.json({ ok: true, payload })
 }

--- a/tests/notifications.api.test.ts
+++ b/tests/notifications.api.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+
+const ORIGINAL_BASE = process.env.NEXT_PUBLIC_BASE_URL;
 
 describe("GET /api/notifications/test", () => {
-  it("returns a simulated reminder payload with a provided recipient", async () => {
+  afterEach(() => {
+    if (ORIGINAL_BASE) process.env.NEXT_PUBLIC_BASE_URL = ORIGINAL_BASE;
+    else delete process.env.NEXT_PUBLIC_BASE_URL;
+  });
+
+  it("returns a simulated reminder payload with a provided recipient and deep link", async () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://app.example";
     const { GET } = await import("../src/app/api/notifications/test/route");
     const req = new Request("http://localhost/api/notifications/test?to=user@example.com");
     const res = await GET(req);
@@ -13,17 +21,19 @@ describe("GET /api/notifications/test", () => {
         to: "user@example.com",
         subject: "Flora — You have tasks due today",
         body: "Open Flora and check your Today list.",
-        deepLink: "/today",
+        deepLink: "https://app.example/today",
       },
     });
   });
 
   it("falls back to a default test address when none provided", async () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
     const { GET } = await import("../src/app/api/notifications/test/route");
     const req = new Request("http://localhost/api/notifications/test");
     const res = await GET(req);
     const body = await res.json();
     expect(body.payload.to).toBe("test@example.com");
+    expect(body.payload.deepLink).toBe("/today");
   });
 });
 


### PR DESCRIPTION
## Summary
- support configurable base URL in notification test route
- send reminder placeholder emails with deep links
- document notification deep link implementation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfb68c98c8324a1aa1472468aac2c