### PR TITLE
feat: add notification preferences

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -73,7 +73,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 5. Notifications & Reminders
 - [x] Background job to check due/overdue tasks
 - [x] Email or push notifications with deep links
-- [ ] User controls for quiet hours and per-plant mute
+ - [x] User controls for quiet hours and per-plant mute
 
 ---
 

--- a/src/app/api/notifications/settings/route.ts
+++ b/src/app/api/notifications/settings/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getCurrentUserId } from "@/lib/auth";
+
+function supabaseServer() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  if (!url || !key) throw new Error("Missing SUPABASE env vars");
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function GET() {
+  try {
+    const supabase = supabaseServer();
+    const userId = await getCurrentUserId();
+    const { data, error } = await supabase
+      .from("notification_settings")
+      .select("quiet_start, quiet_end")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (error) throw error;
+    return NextResponse.json({ settings: data }, { status: 200 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const supabase = supabaseServer();
+    const userId = await getCurrentUserId();
+    const body = await req.json();
+    const updates = {
+      user_id: userId,
+      quiet_start: body.quietStart ?? null,
+      quiet_end: body.quietEnd ?? null,
+    };
+    const { data, error } = await supabase
+      .from("notification_settings")
+      .upsert(updates)
+      .select("quiet_start, quiet_end")
+      .single();
+    if (error) throw error;
+    return NextResponse.json({ settings: data }, { status: 200 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -54,6 +54,8 @@ export async function PATCH(
     if (body.image_url !== undefined) updates.image_url = body.image_url;
     if (body.archived !== undefined) updates.archived = body.archived;
     if (body.waterEvery !== undefined) updates.water_every = body.waterEvery;
+    if (body.notificationsMuted !== undefined)
+      updates.notifications_muted = body.notificationsMuted;
     const updateBuilder = supabase
       .from("plants")
       .update(updates)

--- a/supabase/functions/notify-tasks/index.ts
+++ b/supabase/functions/notify-tasks/index.ts
@@ -6,14 +6,42 @@ const userId = Deno.env.get("NEXT_PUBLIC_SINGLE_USER_ID") ?? "flora-single-user"
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 
-Deno.serve(async () => {
+function withinQuietHours(start: string | null, end: string | null): boolean {
+  if (!start || !end) return false;
+  const now = new Date();
+  const [sh, sm] = start.split(":" ).map(Number);
+  const [eh, em] = end.split(":" ).map(Number);
+  const startDate = new Date(now); startDate.setHours(sh, sm, 0, 0);
+  const endDate = new Date(now); endDate.setHours(eh, em, 0, 0);
+  if (startDate <= endDate) {
+    return now >= startDate && now < endDate;
+  }
+  // Quiet hours span midnight
+  return now >= startDate || now < endDate;
+}
+
+export async function handler() {
   const today = new Date().toISOString().slice(0, 10);
+
+  const { data: settings } = await supabase
+    .from("notification_settings")
+    .select("quiet_start, quiet_end")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (withinQuietHours(settings?.quiet_start ?? null, settings?.quiet_end ?? null)) {
+    return new Response(JSON.stringify({ message: "Within quiet hours" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const { data, error } = await supabase
     .from("tasks")
-    .select("type, plant:plants(nickname)")
+    .select("type, plant:plants(nickname, notifications_muted)")
     .lte("due_date", today)
     .is("completed_at", null)
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .eq("plant.notifications_muted", false);
 
   if (error) {
     console.error("Error fetching tasks", error.message);
@@ -47,4 +75,8 @@ Deno.serve(async () => {
   return new Response(JSON.stringify({ sent: messages.length, messages }), {
     headers: { "Content-Type": "application/json" },
   });
-});
+}
+
+if (import.meta.main) {
+  Deno.serve(handler);
+}

--- a/supabase/notification_settings.sql
+++ b/supabase/notification_settings.sql
@@ -1,0 +1,24 @@
+-- Run in Supabase SQL editor to manage notification preferences
+
+create table if not exists public.notification_settings (
+  user_id text primary key,
+  quiet_start time,
+  quiet_end time,
+  created_at timestamptz default now()
+);
+
+-- Row Level Security
+alter table public.notification_settings enable row level security;
+
+drop policy if exists "user read notification_settings" on public.notification_settings;
+drop policy if exists "user upsert notification_settings" on public.notification_settings;
+drop policy if exists "user update notification_settings" on public.notification_settings;
+
+create policy "user read notification_settings" on public.notification_settings
+  for select using (auth.uid()::text = user_id);
+
+create policy "user upsert notification_settings" on public.notification_settings
+  for insert with check (auth.uid()::text = user_id);
+
+create policy "user update notification_settings" on public.notification_settings
+  for update using (auth.uid()::text = user_id);

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -21,6 +21,7 @@ create table if not exists public.plants (
   image_url text,
   care_plan jsonb,
   archived boolean default false,
+  notifications_muted boolean default false,
   created_at timestamptz default now()
 );
 
@@ -46,6 +47,7 @@ alter table if exists public.plants add column if not exists indoor text;
 alter table if exists public.plants add column if not exists humidity text;
 alter table if exists public.plants add column if not exists user_id text not null default 'flora-single-user';
 alter table if exists public.plants add column if not exists archived boolean default false;
+alter table if exists public.plants add column if not exists notifications_muted boolean default false;
 
 -- Species table
 create table if not exists public.species (

--- a/tests/notification-settings.api.test.ts
+++ b/tests/notification-settings.api.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+let upserted: Record<string, unknown> | null = null;
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => Promise.resolve("user-123"),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "notification_settings") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: { quiet_start: "22:00", quiet_end: "07:00" }, error: null }),
+            }),
+          }),
+          upsert: (values: Record<string, unknown>) => {
+            upserted = values;
+            return {
+              select: () => ({
+                single: () => Promise.resolve({ data: values, error: null }),
+              }),
+            };
+          },
+        };
+      }
+      return {} as any;
+    },
+  }),
+}));
+
+describe("/api/notifications/settings", () => {
+  beforeEach(() => {
+    upserted = null;
+  });
+
+  it("returns existing settings", async () => {
+    const { GET } = await import("../src/app/api/notifications/settings/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.settings).toEqual({ quiet_start: "22:00", quiet_end: "07:00" });
+  });
+
+  it("upserts settings on PATCH", async () => {
+    const { PATCH } = await import("../src/app/api/notifications/settings/route");
+    const req = new Request("http://localhost", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ quietStart: "21:00", quietEnd: "06:00" }),
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    expect(upserted).toEqual({ user_id: "user-123", quiet_start: "21:00", quiet_end: "06:00" });
+  });
+});
+
+export {};

--- a/tests/plant-mute.api.test.ts
+++ b/tests/plant-mute.api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const updates: Record<string, unknown>[] = [];
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => Promise.resolve("user-123"),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      update: (values: Record<string, unknown>) => {
+        updates.push(values);
+        return {
+          eq: () => ({
+            select: () => ({
+              single: () => Promise.resolve({ data: {}, error: null }),
+            }),
+          }),
+        };
+      },
+    }),
+  }),
+}));
+
+describe("PATCH /api/plants/[id]", () => {
+  it("updates notifications_muted when provided", async () => {
+    const { PATCH } = await import("../src/app/api/plants/[id]/route");
+    const req = new Request("http://localhost", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notificationsMuted: true }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "plant-1" }) });
+    expect(res.status).toBe(200);
+    expect(updates[0].notifications_muted).toBe(true);
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- allow muting notifications per plant and update notify-tasks to respect setting
- add quiet hours notification preferences with API endpoints and DB schemas
- mark notifications task complete in implementation guide

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@radix-ui/react-avatar" from some test files)*

------
https://chatgpt.com/codex/tasks/task_e_68acfccb7a7c8324bf1904d20bb73443