### PR TITLE
fix build with lightningcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "CSS_TRANSFORMER_WASM=true next dev --turbopack",
+    "build": "CSS_TRANSFORMER_WASM=true next build --turbopack",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- set CSS_TRANSFORMER_WASM=true for dev and build scripts so lightningcss uses WASM and avoids dynamic .node resolution

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@radix-ui/react-avatar" from "src/components/ui/avatar.tsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68acfc36cd0883249383a6d4653b5776