### PR TITLE
feat: define care event types

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -78,7 +78,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 6. Logging & Timeline
-- [ ] Define event types (watered, fertilized, notes, photos, etc.)
+- [x] Define event types (watered, fertilized, notes, photos, etc.)
 - [ ] Entry points for logging from Today and plant detail views
 - [ ] Persist events and display them chronologically
 

--- a/src/lib/aiCare.ts
+++ b/src/lib/aiCare.ts
@@ -1,8 +1,9 @@
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
+import type { CareEventType } from "@/types";
 
 export interface CareContext {
-  events: { type: string; note: string | null; created_at: string }[];
+  events: { type: CareEventType; note: string | null; created_at: string }[];
   weather: {
     tempMax?: number;
     tempMin?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,21 @@
+// Supported care event types logged for a plant.
+export const CARE_EVENT_TYPES = [
+  "water",
+  "fertilize",
+  "note",
+  "photo",
+] as const;
+
+export type CareEventType = (typeof CARE_EVENT_TYPES)[number];
+
+// Additional entries used when hydrating the timeline with upcoming due items.
+export type CareEventTimelineType =
+  | CareEventType
+  | `${CareEventType} due`;
+
 export interface CareEvent {
   id: string;
-  type: string;
+  type: CareEventTimelineType;
   note: string | null;
   image_url: string | null;
   created_at: string;

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,7 +1,9 @@
+import type { CareEventType } from "@/types";
+
 export type Event = {
   id: string;
   plant_id: string;
-  type: string;
+  type: CareEventType;
   note: string | null;
   image_url: string | null;
   public_id: string | null;


### PR DESCRIPTION
## Summary
- add union and constants for care event types
- use typed event types in AI care context
- mark event type task complete

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfddd61f48324a2f744f21da67c6e