### PR TITLE
feat: add logging entry point

### DIFF
--- a/__tests__/task-list.test.tsx
+++ b/__tests__/task-list.test.tsx
@@ -30,11 +30,34 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/avatar", () => ({
+  __esModule: true,
+  Avatar: ({ children }: any) => <div>{children}</div>,
+  AvatarFallback: ({ children }: any) => <div>{children}</div>,
+}));
+
 describe("TaskList empty state", () => {
   it("shows call to add a plant when no tasks", () => {
     render(<TaskList tasks={[]} />);
     expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /Add a Plant/i });
     expect(link).toHaveAttribute("href", "/plants/new");
+  });
+});
+
+describe("TaskList task actions", () => {
+  it("links to event logging from each task", () => {
+    const tasks = [
+      {
+        id: "1",
+        plantId: "abc",
+        plantName: "Fern",
+        type: "water" as const,
+        due: new Date().toISOString(),
+      },
+    ];
+    render(<TaskList tasks={tasks} />);
+    const logLink = screen.getByRole("link", { name: /log/i });
+    expect(logLink).toHaveAttribute("href", "/plants/abc#log-event");
   });
 });

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -79,7 +79,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ## 6. Logging & Timeline
 - [x] Define event types (watered, fertilized, notes, photos, etc.)
-- [ ] Entry points for logging from Today and plant detail views
+- [x] Entry points for logging from Today and plant detail views
 - [ ] Persist events and display them chronologically
 
 ---

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -57,6 +57,9 @@ export default function TaskCard({
           </DropdownMenuContent>
         </DropdownMenu>
         <Button asChild variant="outline" size="sm">
+          <Link href={`/plants/${task.plantId}#log-event`}>Log</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
           <Link href={`/plants/${task.plantId}`}>View</Link>
         </Button>
       </div>

--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -34,7 +34,7 @@ export function EventQuickAdd({ plantId }: Props) {
   }
 
   return (
-    <div className="rounded-xl border bg-card p-4 space-y-3">
+    <div id="log-event" className="rounded-xl border bg-card p-4 space-y-3">
       <div className="flex gap-2">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- add Log button on today task cards to jump to event logging
- anchor quick-add form in plant page for direct linking
- document logging entry points

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acff569ce08324bce8d50776790b4e