### PR TITLE
Refresh timeline after logging events

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -80,7 +80,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 6. Logging & Timeline
 - [x] Define event types (watered, fertilized, notes, photos, etc.)
 - [x] Entry points for logging from Today and plant detail views
-- [ ] Persist events and display them chronologically
+- [x] Persist events and display them chronologically
 
 ---
 

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -105,6 +105,8 @@ export default async function PlantDetailPage({
           <PlantTabs
             plantId={plant.id}
             initialEvents={timelineEvents}
+            waterEvery={plant.waterEvery}
+            fertEvery={plant.fertEvery}
             timelineError={timelineError}
           />
         </div>

--- a/tests/planttabs.test.tsx
+++ b/tests/planttabs.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PlantTabs from '../src/components/plant/PlantTabs';
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock('../src/components/plant/EventQuickAdd', () => ({ EventQuickAdd: () => null }));
+vi.mock('../src/components/AddNoteForm', () => ({ default: () => null }));
+vi.mock('../src/components/AddPhotoForm', () => ({ default: () => null }));
+vi.mock('../src/components/plant/PhotoGalleryClient', () => ({ default: () => null }));
+vi.mock('../src/components/CareTimeline', () => ({ default: () => null }));
+vi.mock('../src/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('PlantTabs', () => {
+  it('refetches events when flora:events:changed fires', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    const spy = vi.spyOn(global, 'fetch').mockImplementation(fetchMock as any);
+
+    render(<PlantTabs plantId="p1" initialEvents={[]} waterEvery="7 days" fertEvery={null} />);
+
+    window.dispatchEvent(
+      new CustomEvent('flora:events:changed', { detail: { plantId: 'p1' } })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/events?plantId=p1');
+    });
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- mark logging & timeline task as complete
- refresh plant timeline when care events are logged
- pass scheduling info to tabs and rehydrate fetched events
- add unit test for timeline refresh

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "@radix-ui/react-avatar")*
- `pnpm test tests/planttabs.test.tsx tests/eventquickadd.test.tsx tests/plant.page.test.tsx tests/caretimeline.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ad012156cc8324b905336b0dca89fd