### PR TITLE
feat: allow custom species entry

### DIFF
--- a/__tests__/add-plant-form.test.tsx
+++ b/__tests__/add-plant-form.test.tsx
@@ -12,11 +12,19 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/components/plant/SpeciesAutosuggest", () => ({
   __esModule: true,
-  default: ({ value = "", onSelect }: { value?: string; onSelect: (s: string, c?: string) => void }) => (
+  default: ({
+    value = "",
+    onSelect,
+    onInputChange,
+  }: {
+    value?: string;
+    onSelect: (s: string, c?: string) => void;
+    onInputChange?: (v: string) => void;
+  }) => (
     <input
       aria-label="species"
       value={value}
-      onChange={(e) => onSelect(e.target.value, e.target.value)}
+      onChange={(e) => onInputChange?.(e.target.value)}
     />
   ),
 }));
@@ -56,7 +64,7 @@ describe("AddPlantForm validation", () => {
       screen.getByText(/please enter a nickname/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/please select a species/i),
+      screen.getByText(/please enter a species/i),
     ).toBeInTheDocument();
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -88,7 +96,10 @@ describe("AddPlantForm submission", () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/plants",
-        expect.objectContaining({ method: "POST" })
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"speciesCommon":"Pothos"'),
+        })
       );
       expect(push).toHaveBeenCalledWith("/plants/42");
     });

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -98,7 +98,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 9. Error & Empty-State Handling
-- [ ] Free-text species when no match
+- [x] Free-text species when no match
 - [ ] Queue events offline and sync when back online
 - [ ] Graceful API error handling and missing permissions
 

--- a/src/components/plant/AddPlantForm.tsx
+++ b/src/components/plant/AddPlantForm.tsx
@@ -25,6 +25,7 @@ export default function AddPlantForm(): JSX.Element {
   const [nickname, setNickname] = useState<string>("");
   const [speciesScientific, setSpeciesScientific] = useState<string>("");
   const [speciesCommon, setSpeciesCommon] = useState<string>("");
+  const [speciesInput, setSpeciesInput] = useState<string>("");
   const [roomId, setRoomId] = useState<number | null>(null);
   const [pot, setPot] = useState<string>("");
   const [light, setLight] = useState<string>("");
@@ -60,8 +61,8 @@ export default function AddPlantForm(): JSX.Element {
 
     const newErrors: { nickname?: string; species?: string } = {};
     if (!nickname.trim()) newErrors.nickname = "Please enter a nickname";
-    if (!speciesScientific && !speciesCommon)
-      newErrors.species = "Please select a species";
+    if (!speciesScientific && !speciesCommon && !speciesInput.trim())
+      newErrors.species = "Please enter a species";
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
       return;
@@ -73,7 +74,7 @@ export default function AddPlantForm(): JSX.Element {
       const payload: CreatePayload = {
         nickname: nickname.trim(),
         speciesScientific: speciesScientific || null,
-        speciesCommon: speciesCommon || null,
+        speciesCommon: speciesCommon || speciesInput || null,
         room_id: roomId,
         pot: pot.trim() || null,
         light: light.trim() || null,
@@ -120,12 +121,19 @@ export default function AddPlantForm(): JSX.Element {
       <div className="space-y-2">
         <Label>Species</Label>
         <SpeciesAutosuggest
-          value={speciesCommon || speciesScientific}
+          value={speciesCommon || speciesScientific || speciesInput}
           onSelect={(scientific, common) => {
             setSpeciesScientific(scientific);
             setSpeciesCommon(common || "");
+            setSpeciesInput(common || scientific);
             setErrors((er) => ({ ...er, species: undefined }));
             fetchPreview(scientific, common);
+          }}
+          onInputChange={(val) => {
+            setSpeciesInput(val);
+            setSpeciesScientific("");
+            setSpeciesCommon("");
+            setErrors((er) => ({ ...er, species: undefined }));
           }}
         />
         {errors.species && (

--- a/src/components/plant/SpeciesAutosuggest.tsx
+++ b/src/components/plant/SpeciesAutosuggest.tsx
@@ -16,10 +16,11 @@ type Item = { scientific: string; common?: string };
 export default function SpeciesAutosuggest(props: {
   value?: string;
   onSelect: (scientific: string, common?: string) => void;
+  onInputChange?: (val: string) => void;
   placeholder?: string;
   className?: string;
 }) {
-  const { value = "", onSelect, placeholder = "Search species…", className } = props;
+  const { value = "", onSelect, onInputChange, placeholder = "Search species…", className } = props;
   const [query, setQuery] = React.useState(value);
   const debounced = useDebounce(query, 350);
   const [items, setItems] = React.useState<Item[]>([]);
@@ -59,6 +60,7 @@ export default function SpeciesAutosuggest(props: {
         onValueChange={(val) => {
           setQuery(val);
           setOpen(true);
+          onInputChange?.(val);
         }}
         onFocus={() => setOpen(true)}
         onBlur={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- allow manual species entry when suggestions are unavailable
- surface typed species from autosuggest to add plant form
- document free-text species support

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad06fc2fe48324ab41523488c736fc