### PR TITLE
Add dashboard stats test

### DIFF
--- a/__tests__/dashboard.api.test.ts
+++ b/__tests__/dashboard.api.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { GET as DashboardGET } from "@/app/api/dashboard/route"
+
+// Freeze time for deterministic results
+vi.setSystemTime(new Date("2025-01-08T12:00:00Z"))
+
+// Mock supabase client used in the route
+vi.mock("@supabase/supabase-js", () => {
+  const events = [
+    { id: 1, created_at: "2025-01-08T09:00:00Z", plant_id: 1, type: "water" },
+    { id: 2, created_at: "2025-01-07T09:00:00Z", plant_id: 1, type: "water" },
+    { id: 3, created_at: "2025-01-06T09:00:00Z", plant_id: 2, type: "fertilize" },
+  ]
+  const plants = [
+    { id: 1, name: "Aloe" },
+    { id: 2, name: "Fern" },
+  ]
+  const tasks = [
+    { id: 1, plant_id: 1, type: "water", due_date: "2025-01-07", completed_at: null },
+    { id: 2, plant_id: 2, type: "fertilize", due_date: "2025-01-08", completed_at: "2025-01-08" },
+  ]
+
+  function createClient(_url: string, _key: string) {
+    return {
+      from(table: string) {
+        if (table === "events") {
+          return {
+            select() {
+              return {
+                gte() {
+                  return { data: events, error: null }
+                },
+              }
+            },
+          }
+        }
+        if (table === "plants") {
+          return {
+            select() {
+              return { data: plants, error: null }
+            },
+          }
+        }
+        if (table === "tasks") {
+          return {
+            select() {
+              return {
+                lte() {
+                  return {
+                    order() {
+                      return { data: tasks, error: null }
+                    },
+                  }
+                },
+              }
+            },
+          }
+        }
+        throw new Error("Unexpected table: " + table)
+      },
+    }
+  }
+  return { createClient }
+})
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost"
+  process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "test_key"
+})
+
+describe("/api/dashboard", () => {
+  it("returns computed stats", async () => {
+    const res = await DashboardGET()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toMatchObject({
+      completion: 100,
+      totalDone: 3,
+      plants: 2,
+      streak: 3,
+    })
+    expect(json.attention).toHaveLength(1)
+    expect(json.attention[0].plantName).toBe("Aloe")
+    expect(Array.isArray(json.hist)).toBe(true)
+    expect(json.hist).toHaveLength(7)
+    expect(Array.isArray(json.overdueTrend)).toBe(true)
+    expect(json.overdueTrend).toHaveLength(7)
+  })
+})
+

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -85,8 +85,8 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 7. Dashboard & Insights (`/dashboard`)
-- [ ] Create widgets for completion rate, overdue trends, and streaks
-- [ ] Highlight plants needing attention
+- [x] Create widgets for completion rate, overdue trends, and streaks
+- [x] Highlight plants needing attention
 - [ ] (Optional) Graph ET₀/weather vs. watering patterns
 
 ---


### PR DESCRIPTION
## Summary
- mark dashboard tasks complete in implementation guide
- add unit test covering dashboard API stats

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0894d72c8324bd1ed2b4050c3bd8