### PR TITLE
feat: add plant hero section

### DIFF
--- a/docs/design-tasks.md
+++ b/docs/design-tasks.md
@@ -112,7 +112,7 @@ export function SpeciesAutosuggest() {
 
 ## 3. Plant Detail Page
 
-- [ ] **Hero Section**
+- [x] **Hero Section**
   - Crop hero photo consistently (16:9)
   - Overlay gradient for text legibility
   - Room badge = pill style

--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-import Link from "next/link";
 import db from "@/lib/db";
 import QuickStats from "@/components/plant/QuickStats";
 import ScheduleAdjuster from "@/components/plant/ScheduleAdjuster";
@@ -7,7 +5,7 @@ import CareCoach from "@/components/plant/CareCoach";
 import CareNudge from "@/components/CareNudge";
 import PlantTabs from "@/components/plant/PlantTabs";
 import WaterPlantButton from "@/components/plant/WaterPlantButton";
-import { Button } from "@/components/ui/button";
+import PlantHero from "@/components/plant/PlantHero";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { hydrateTimeline } from "@/lib/tasks";
 import { getCurrentUserId } from "@/lib/auth";
@@ -63,53 +61,21 @@ export default async function PlantDetailPage({
 
   return (
     <div>
-      {heroUrl ? (
-        <Image
-          src={heroUrl}
-          alt={plant.nickname}
-          width={800}
-          height={400}
-          className="h-48 w-full rounded-xl object-cover md:h-64"
-        />
-      ) : (
-        <div className="h-48 w-full rounded-xl bg-muted md:h-64" />
-      )}
+      <PlantHero plant={plant} heroUrl={heroUrl} />
       <div className="p-4 md:p-6 max-w-3xl mx-auto">
-        <div className="mt-4 flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">{plant.nickname}</h2>
-            {(plant.speciesScientific || plant.speciesCommon) && (
-              <p className="text-sm text-muted-foreground">
-                {plant.speciesScientific || plant.speciesCommon}
-              </p>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            {plant.room?.name && (
-              <span className="rounded-md bg-secondary px-2 py-1 text-xs font-medium">
-                {plant.room.name}
-              </span>
-            )}
-            <Link href={`/plants/${plant.id}/edit`}>
-              <Button variant="outline" size="sm">
-                Edit
-              </Button>
-            </Link>
-          </div>
-        </div>
         <QuickStats plant={plant} />
         <ScheduleAdjuster plantId={plant.id} waterEvery={plant.waterEvery} />
         <WaterPlantButton plantId={plant.id} />
         <CareNudge plantId={plant.id} />
-          <CareCoach plant={plant} />
-          <PlantTabs
-            plantId={plant.id}
-            initialEvents={timelineEvents}
-            waterEvery={plant.waterEvery}
-            fertEvery={plant.fertEvery}
-            timelineError={timelineError}
-          />
-        </div>
+        <CareCoach plant={plant} />
+        <PlantTabs
+          plantId={plant.id}
+          initialEvents={timelineEvents}
+          waterEvery={plant.waterEvery}
+          fertEvery={plant.fertEvery}
+          timelineError={timelineError}
+        />
       </div>
-    );
-  }
+    </div>
+  );
+}

--- a/src/components/plant/PlantHero.tsx
+++ b/src/components/plant/PlantHero.tsx
@@ -1,0 +1,47 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface PlantHeroProps {
+  plant: {
+    id: string;
+    nickname: string;
+    speciesScientific?: string | null;
+    speciesCommon?: string | null;
+    room?: { name: string | null } | null;
+  };
+  heroUrl: string | null;
+}
+
+export default function PlantHero({ plant, heroUrl }: PlantHeroProps) {
+  const species = plant.speciesScientific || plant.speciesCommon;
+  return (
+    <div className="relative w-full overflow-hidden rounded-xl aspect-video">
+      {heroUrl ? (
+        <Image src={heroUrl} alt={plant.nickname} fill className="object-cover" />
+      ) : (
+        <div className="absolute inset-0 bg-muted" />
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+      <div className="absolute bottom-4 left-4 right-4 flex items-end justify-between">
+        <div className="text-white drop-shadow">
+          <h2 className="text-xl font-semibold">{plant.nickname}</h2>
+          {species && <p className="text-sm text-white/80">{species}</p>}
+        </div>
+        <div className="flex items-center gap-2">
+          {plant.room?.name && (
+            <Badge className="bg-white/20 text-white backdrop-blur-sm" variant="secondary">
+              {plant.room.name}
+            </Badge>
+          )}
+          <Link href={`/plants/${plant.id}/edit`}>
+            <Button variant="outline" size="sm" className="bg-white/20 text-white hover:bg-white/30">
+              Edit
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-transparent px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- implement reusable Badge component
- add PlantHero with gradient overlay and pill room badge
- integrate PlantHero into plant detail page and update design tasks

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad09740760832490eb6e77cc242d3c