### PR TITLE
feat: support photo uploads for events

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -92,8 +92,8 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ---
 
 ## 8. Edit & Maintenance
-- [ ] Edit metadata, replace photo
-- [ ] Archive/delete flows
+- [x] Edit metadata, replace photo
+- [x] Archive/delete flows
 
 ---
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "@/lib/auth";
+import cloudinary from "@/lib/cloudinary";
 
 function supabaseServer() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -37,9 +38,32 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    const plantId = body?.plant_id as string;
-    const type = body?.type as string;
+    const contentType = req.headers.get("content-type") || "";
+    let plantId: string | null = null;
+    let type: string | null = null;
+    let note: string | null = null;
+    let amount: number | null = null;
+    let imageUrl: string | null = null;
+    let file: File | null = null;
+
+    if (!contentType || !contentType.includes("application/json")) {
+      const form = await req.formData();
+      plantId = form.get("plant_id")?.toString() || null;
+      type = form.get("type")?.toString() || null;
+      note = typeof form.get("note") === "string" ? (form.get("note") as string) : null;
+      const amt = form.get("amount");
+      amount = typeof amt === "string" && amt ? Number(amt) : null;
+      const f = form.get("photo");
+      file = f instanceof File ? f : null;
+    } else {
+      const body = await req.json();
+      plantId = body?.plant_id ?? null;
+      type = body?.type ?? null;
+      note = typeof body?.note === "string" ? body.note : null;
+      amount = body?.amount ?? null;
+      imageUrl = typeof body?.photoUrl === "string" ? body.photoUrl : null;
+    }
+
     if (!plantId || !type || typeof plantId !== "string" || typeof type !== "string") {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
@@ -50,12 +74,48 @@ export async function POST(req: Request) {
 
     const userId = await getCurrentUserId();
     const supabase = supabaseServer();
+    let publicId: string | null = null;
+
+    if (type === "photo") {
+      if (file) {
+        const upload = await new Promise<{ secure_url: string; public_id: string }>(async (resolve, reject) => {
+          const stream = cloudinary.uploader.upload_stream({}, (err, result) => {
+            if (err || !result) return reject(err);
+            resolve(result);
+          });
+          try {
+            if (typeof (file as any).arrayBuffer === "function") {
+              const arrayBuffer = await (file as any).arrayBuffer();
+              stream.end(Buffer.from(arrayBuffer));
+            } else if (typeof (file as any).stream === "function") {
+              const arrayBuffer = await new Response((file as any).stream()).arrayBuffer();
+              stream.end(Buffer.from(arrayBuffer));
+            } else if (typeof (file as any).text === "function") {
+              const text = await (file as any).text();
+              stream.end(Buffer.from(text));
+            } else {
+              stream.end();
+            }
+          } catch (err) {
+            stream.end();
+          }
+        });
+        imageUrl = upload.secure_url;
+        publicId = upload.public_id;
+        await supabase.from("plants").update({ image_url: imageUrl }).eq("id", plantId);
+      }
+      if (!imageUrl) {
+        return NextResponse.json({ error: "Photo required" }, { status: 400 });
+      }
+    }
+
     const payload = {
       plant_id: plantId,
       type,
-      note: typeof body?.note === "string" ? body.note : null,
-      amount: body?.amount ?? null,
-      photo_url: typeof body?.photoUrl === "string" ? body.photoUrl : null,
+      note,
+      amount,
+      image_url: imageUrl,
+      public_id: publicId,
       user_id: userId,
     };
 

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -168,7 +168,7 @@ describe("POST /api/events", () => {
     });
   });
 
-  it.skip("updates plant image_url when uploading a photo", async () => {
+  it("updates plant image_url when uploading a photo", async () => {
     const { POST } = await import("../src/app/api/events/route");
     const form = new FormData();
     form.set("plant_id", "4aa97bee-71f1-428e-843b-4c3c77493994");


### PR DESCRIPTION
## Summary
- allow `/api/events` to handle photo uploads and update a plant's hero image
- document completion of edit and archive maintenance tasks
- enable test for photo upload workflow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad09767ec0832492e9983288f7df60