### PR TITLE
feat: queue events offline and sync on reconnect

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -99,7 +99,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ## 9. Error & Empty-State Handling
 - [x] Free-text species when no match
-- [ ] Queue events offline and sync when back online
+- [x] Queue events offline and sync when back online
 - [ ] Graceful API error handling and missing permissions
 
 ---

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from 'sonner';
 import SiteNav from '@/components/SiteNav';
 import LocationProvider from '@/components/LocationProvider';
+import OfflineQueueProvider from '@/components/OfflineQueueProvider';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="flex min-h-screen flex-col bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <LocationProvider />
+          <OfflineQueueProvider />
           <SiteNav />
           <main className="flex-1">{children}</main>
           <Toaster richColors />

--- a/src/components/OfflineQueueProvider.tsx
+++ b/src/components/OfflineQueueProvider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect } from 'react';
+import { startQueue } from '@/lib/offlineQueue';
+
+export default function OfflineQueueProvider() {
+  useEffect(() => {
+    startQueue();
+  }, []);
+  return null;
+}

--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { queueEvent, type EventPayload } from "@/lib/offlineQueue";
 
 type Props = { plantId: string };
 
@@ -11,7 +12,7 @@ export function EventQuickAdd({ plantId }: Props) {
   async function add(type: "water" | "fertilize" | "note") {
     if (loading) return; // prevent duplicate submissions
 
-    const payload: Record<string, unknown> = { plant_id: plantId, type };
+    const payload: EventPayload = { plant_id: plantId, type } as EventPayload;
     if (type === "note" && note.trim()) payload.note = note.trim();
 
     try {
@@ -27,7 +28,11 @@ export function EventQuickAdd({ plantId }: Props) {
         window.dispatchEvent(
           new CustomEvent("flora:events:changed", { detail: { plantId } }),
         );
+      } else if (!navigator.onLine) {
+        queueEvent(payload);
       }
+    } catch {
+      queueEvent(payload);
     } finally {
       setLoading(false);
     }

--- a/src/components/plant/WaterPlantButton.tsx
+++ b/src/components/plant/WaterPlantButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { queueEvent } from '@/lib/offlineQueue';
 
 interface Props {
   plantId: string;
@@ -15,15 +16,17 @@ export default function WaterPlantButton({ plantId }: Props) {
   async function handleClick() {
     if (saving) return;
     setSaving(true);
+    const payload = { plant_id: plantId, type: 'water' };
     try {
       await fetch('/api/events', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plant_id: plantId, type: 'water' }),
+        body: JSON.stringify(payload),
       });
       router.refresh();
     } catch (err) {
       console.error('Failed to mark as watered', err);
+      queueEvent(payload);
     } finally {
       setSaving(false);
     }

--- a/src/lib/offlineQueue.ts
+++ b/src/lib/offlineQueue.ts
@@ -1,0 +1,73 @@
+const QUEUE_KEY = 'flora:offline-events';
+
+export type EventPayload = {
+  plant_id: string;
+  type: string;
+  note?: string;
+  amount?: number;
+};
+
+function getQueue(): EventPayload[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY);
+    return raw ? (JSON.parse(raw) as EventPayload[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveQueue(queue: EventPayload[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  } catch {
+    // ignore
+  }
+}
+
+export async function flushQueue() {
+  const queue = getQueue();
+  if (queue.length === 0) return;
+  const remaining: EventPayload[] = [];
+  for (const payload of queue) {
+    try {
+      const res = await fetch('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        window.dispatchEvent(
+          new CustomEvent('flora:events:changed', {
+            detail: { plantId: payload.plant_id },
+          })
+        );
+      } else {
+        remaining.push(payload);
+      }
+    } catch {
+      remaining.push(payload);
+    }
+  }
+  saveQueue(remaining);
+}
+
+let started = false;
+export function startQueue() {
+  if (started || typeof window === 'undefined') return;
+  started = true;
+  window.addEventListener('online', flushQueue);
+  if (navigator.onLine) {
+    flushQueue();
+  }
+}
+
+export function queueEvent(payload: EventPayload) {
+  const queue = getQueue();
+  queue.push(payload);
+  saveQueue(queue);
+  startQueue();
+}
+
+export { QUEUE_KEY };

--- a/tests/offlinequeue.test.ts
+++ b/tests/offlinequeue.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { queueEvent, flushQueue, QUEUE_KEY } from '../src/lib/offlineQueue';
+
+describe('offlineQueue', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('queues payloads and flushes when online', async () => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+    const payload = { plant_id: '1', type: 'note', note: 'hi' };
+    queueEvent(payload);
+    expect(JSON.parse(localStorage.getItem(QUEUE_KEY) || '[]')).toHaveLength(1);
+
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true,
+    });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const dispatchMock = vi.fn();
+    window.dispatchEvent = dispatchMock as any;
+
+    await flushQueue();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalled();
+    expect(localStorage.getItem(QUEUE_KEY)).toBe('[]');
+  });
+});


### PR DESCRIPTION
## Summary
- add localStorage-backed offline event queue with auto-flush on reconnect
- integrate offline queue provider and hook forms/buttons to queue failed event posts
- mark offline event sync task complete

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0dd78cc08324875ed930c1c707e2