### PR TITLE
Add alt text for plant images

### DIFF
--- a/docs/design-tasks.md
+++ b/docs/design-tasks.md
@@ -251,7 +251,7 @@ export function TaskSkeleton() {
 ## 8. Accessibility
 
 - [ ] Ensure shadcn/ui defaults (`aria-*` props) aren’t removed
-- [ ] Add alt text for plant photos
+- [x] Add alt text for plant photos
 - [ ] Test keyboard nav across `<Tabs>`, `<DropdownMenu>`, `<Command>`
 - [ ] Confirm high-contrast mode works with tokens
 

--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -65,7 +65,7 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
                       <div className="relative w-full h-48 rounded-xl overflow-hidden">
                         <Image
                           src={plant.imageUrl}
-                          alt="Plant photo"
+                          alt={`Photo of ${plant.nickname}`}
                           fill
                           className="h-12 w-12 rounded-lg object-cover"
                           sizes="(min-width: 768px) 768px, 100vw"

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -18,7 +18,7 @@ export default async function PhotoGallery({ plantId }: { plantId: string }) {
         <Image
           key={photo.id}
           src={photo.url ?? ''}
-          alt="Plant photo"
+          alt="Photo of plant"
           width={300}
           height={300}
           className="h-32 w-full rounded-lg object-cover"

--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -14,7 +14,7 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
         <Image
           key={photo.id}
           src={photo.image_url || ''}
-          alt={photo.note ?? 'Plant photo'}
+          alt={photo.note ?? 'Photo of plant'}
           width={300}
           height={300}
           className="h-32 w-full rounded-lg object-cover"

--- a/src/components/plant/PlantCard.tsx
+++ b/src/components/plant/PlantCard.tsx
@@ -18,7 +18,7 @@ export default function PlantCard({ plant }: { plant: Plant }) {
       {plant.imageUrl ? (
         <Image
           src={plant.imageUrl}
-          alt={plant.nickname}
+          alt={`Photo of ${plant.nickname}`}
           width={400}
           height={300}
           className="h-40 w-full object-cover"

--- a/src/components/plant/PlantHero.tsx
+++ b/src/components/plant/PlantHero.tsx
@@ -19,7 +19,12 @@ export default function PlantHero({ plant, heroUrl }: PlantHeroProps) {
   return (
     <div className="relative w-full overflow-hidden rounded-xl aspect-video">
       {heroUrl ? (
-        <Image src={heroUrl} alt={plant.nickname} fill className="object-cover" />
+        <Image
+          src={heroUrl}
+          alt={`Photo of ${plant.nickname}`}
+          fill
+          className="object-cover"
+        />
       ) : (
         <div className="absolute inset-0 bg-muted" />
       )}


### PR DESCRIPTION
## Summary
- provide descriptive alt text for plant imagery across components
- mark accessibility design task as complete

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad11252af48324a8204b82f7125fb4