### PR TITLE
feat: improve API error handling and permission feedback

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -100,7 +100,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 9. Error & Empty-State Handling
 - [x] Free-text species when no match
 - [x] Queue events offline and sync when back online
-- [ ] Graceful API error handling and missing permissions
+- [x] Graceful API error handling and missing permissions
 
 ---
 

--- a/src/app/forecast/page.tsx
+++ b/src/app/forecast/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { generateWeeklyCareForecast } from '@/lib/forecast';
 import type { DayForecast } from '@/types/forecast';
 import type { Plant } from '@/lib/tasks';
+import { apiFetch } from '@/lib/api';
 
 const samplePlants: Plant[] = [
   {
@@ -25,10 +26,13 @@ export default function ForecastPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await fetch('/api/weather');
-      const weather = await res.json();
-      const data = generateWeeklyCareForecast(samplePlants, weather);
-      setForecast(data);
+      try {
+        const weather = await apiFetch<any>('/api/weather');
+        const data = generateWeeklyCareForecast(samplePlants, weather);
+        setForecast(data);
+      } catch {
+        // errors handled by apiFetch
+      }
     }
     load();
   }, []);

--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { CareEvent } from '@/types';
 import { Button } from '@/components/ui/button';
 import { queueEvent } from '@/lib/offlineQueue';
+import { apiFetch } from '@/lib/api';
 
 interface Props {
   plantId: string;
@@ -33,23 +34,19 @@ export default function AddNoteForm({ plantId, onAdd, onReplace }: Props) {
     setNote('');
     const payload = { plant_id: plantId, type: 'note', note: trimmed };
     try {
-      const res = await fetch('/api/events', {
+      const data = await apiFetch<any>('/api/events', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      if (res.ok) {
-        const data = await res.json();
-        const real = Array.isArray(data) ? data[0] : data;
-        if (real) {
-          onReplace(tempId, real);
-        }
-      } else if (!navigator.onLine) {
+      const real = Array.isArray(data) ? data[0] : data;
+      if (real) {
+        onReplace(tempId, real);
+      }
+    } catch {
+      if (!navigator.onLine) {
         queueEvent(payload);
       }
-    } catch (err) {
-      console.error('Failed to add note', err);
-      queueEvent(payload);
     } finally {
       setSaving(false);
     }

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -9,6 +9,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from '@/components/ui/tooltip';
+import { apiFetch } from '@/lib/api';
 
 interface Props {
   plantId: string;
@@ -40,19 +41,16 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
     setFile(null);
     (e.target as HTMLFormElement).reset();
     try {
-      const res = await fetch('/api/events', {
+      const data = await apiFetch<any>('/api/events', {
         method: 'POST',
         body: formData,
       });
-      if (res.ok) {
-        const data = await res.json();
-        const real = Array.isArray(data) ? data[0] : data;
-        if (real) {
-          onReplace(tempId, real);
-        }
+      const real = Array.isArray(data) ? data[0] : data;
+      if (real) {
+        onReplace(tempId, real);
       }
-    } catch (err) {
-      console.error('Failed to upload photo', err);
+    } catch {
+      // error handled by apiFetch toast
     } finally {
       setSaving(false);
     }

--- a/src/components/CareNudge.tsx
+++ b/src/components/CareNudge.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { apiFetch } from '@/lib/api'
 
 interface CareNudgeProps {
   plantId: string
@@ -15,13 +16,12 @@ export default function CareNudge({ plantId }: CareNudgeProps) {
   useEffect(() => {
     async function fetchSuggestion() {
       try {
-        const res = await fetch(`/api/ai-care?plantId=${plantId}`)
-        const json = await res.json()
+        const json = await apiFetch<any>(`/api/ai-care?plantId=${plantId}`)
         if (Array.isArray(json.suggestions) && json.suggestions.length > 0) {
           setSuggestion(json.suggestions[0] as string)
         }
       } catch {
-        // ignore errors
+        // errors toasted by apiFetch
       }
     }
     fetchSuggestion()
@@ -29,13 +29,13 @@ export default function CareNudge({ plantId }: CareNudgeProps) {
 
   async function sendFeedback(feedback: string) {
     try {
-      await fetch('/api/care-feedback', {
+      await apiFetch('/api/care-feedback', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ plant_id: plantId, feedback }),
       })
     } catch {
-      // ignore errors
+      // errors toasted by apiFetch
     }
   }
 

--- a/src/components/LocationProvider.tsx
+++ b/src/components/LocationProvider.tsx
@@ -1,15 +1,21 @@
 'use client';
 
 import { useEffect } from 'react';
+import { toast } from 'sonner';
 import { getLocation } from '@/lib/location';
 import { getWeather } from '@/lib/weather';
 
 export default function LocationProvider() {
   useEffect(() => {
     async function init() {
-      const loc = await getLocation();
-      if (loc) {
-        await getWeather(loc.lat, loc.lon);
+      try {
+        const loc = await getLocation();
+        if (loc) {
+          await getWeather(loc.lat, loc.lon);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unable to access location';
+        toast.error(message);
       }
     }
     init();

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -14,6 +14,7 @@ import type { Task } from '@/types/task';
 import TaskCard from '@/components/TaskCard';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import EmptyTasksState from '@/components/EmptyTasksState';
+import { apiFetch } from '@/lib/api';
 
 function playChime() {
   if (typeof window === 'undefined') return;
@@ -44,13 +45,13 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
 
   const handleComplete = async (id: string) => {
     try {
-      await fetch(`/api/tasks/${id}`, {
+      await apiFetch(`/api/tasks/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'complete' }),
       });
-    } catch (err) {
-      console.error('Failed to complete task', err);
+    } catch {
+      // errors handled by apiFetch toast
     } finally {
       confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
       playChime();
@@ -60,13 +61,13 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
 
   const handleSnooze = async (id: string, days = 1) => {
     try {
-      await fetch(`/api/tasks/${id}`, {
+      await apiFetch(`/api/tasks/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'snooze', days }),
       });
-    } catch (err) {
-      console.error('Failed to snooze task', err);
+    } catch {
+      // errors handled by apiFetch toast
     } finally {
       setTasks((prev) =>
         prev

--- a/src/components/plant/WaterPlantButton.tsx
+++ b/src/components/plant/WaterPlantButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { queueEvent } from '@/lib/offlineQueue';
+import { apiFetch } from '@/lib/api';
 
 interface Props {
   plantId: string;
@@ -18,15 +19,16 @@ export default function WaterPlantButton({ plantId }: Props) {
     setSaving(true);
     const payload = { plant_id: plantId, type: 'water' };
     try {
-      await fetch('/api/events', {
+      await apiFetch('/api/events', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
       router.refresh();
-    } catch (err) {
-      console.error('Failed to mark as watered', err);
-      queueEvent(payload);
+    } catch {
+      if (!navigator.onLine) {
+        queueEvent(payload);
+      }
     } finally {
       setSaving(false);
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { toast } from 'sonner';
+
+export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    let message = 'Request failed';
+    try {
+      const data = await res.json();
+      if (data && typeof data.error === 'string') {
+        message = data.error;
+      }
+    } catch {
+      // ignore JSON parse errors
+    }
+    if (res.status === 401 || res.status === 403) {
+      message = 'You do not have permission to perform this action';
+    }
+    if (typeof window !== 'undefined') {
+      toast.error(message);
+    }
+    throw new Error(message);
+  }
+  return (res.json() as Promise<T>);
+}

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -42,7 +42,15 @@ export async function getLocation(): Promise<UserLocation | null> {
     const location: UserLocation = { city, lat: latitude, lon: longitude };
     localStorage.setItem(LOCATION_KEY, JSON.stringify(location));
     return location;
-  } catch {
+  } catch (err: unknown) {
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err as GeolocationPositionError).code === 1
+    ) {
+      throw new Error('Location permission denied');
+    }
     return null;
   }
 }

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,4 +1,5 @@
 import type { WeatherDay } from '@/types/forecast';
+import { apiFetch } from '@/lib/api';
 
 const WEATHER_KEY = 'flora.weather';
 const WEATHER_TTL = 30 * 60 * 1000; // 30 minutes
@@ -29,12 +30,12 @@ export async function getWeather(lat: number, lon: number): Promise<WeatherDay[]
       localStorage.removeItem(WEATHER_KEY);
     }
   }
-  const res = await fetch(`/api/weather?lat=${lat}&lon=${lon}`);
-  if (!res.ok) {
+  try {
+    const data = await apiFetch<WeatherDay[]>(`/api/weather?lat=${lat}&lon=${lon}`);
+    const cache: WeatherCache = { lat, lon, timestamp: Date.now(), data };
+    localStorage.setItem(WEATHER_KEY, JSON.stringify(cache));
+    return data;
+  } catch {
     return [];
   }
-  const data: WeatherDay[] = await res.json();
-  const cache: WeatherCache = { lat, lon, timestamp: Date.now(), data };
-  localStorage.setItem(WEATHER_KEY, JSON.stringify(cache));
-  return data;
 }


### PR DESCRIPTION
## Summary
- add `apiFetch` helper for consistent error handling with permission messaging
- surface geolocation permission errors via toasts
- use new helper across components and mark error-handling task done

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad114752bc832485342bd0d31de890