### PR TITLE
feat: graph weather vs watering on dashboard

### DIFF
--- a/__tests__/dashboard.api.test.ts
+++ b/__tests__/dashboard.api.test.ts
@@ -66,6 +66,23 @@ vi.mock("@supabase/supabase-js", () => {
 beforeEach(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost"
   process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "test_key"
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      daily: {
+        time: [
+          "2025-01-02",
+          "2025-01-03",
+          "2025-01-04",
+          "2025-01-05",
+          "2025-01-06",
+          "2025-01-07",
+          "2025-01-08",
+        ],
+        et0_fao_evapotranspiration: [1, 1, 1, 1, 1, 1, 1],
+      },
+    }),
+  })
 })
 
 describe("/api/dashboard", () => {
@@ -85,6 +102,8 @@ describe("/api/dashboard", () => {
     expect(json.hist).toHaveLength(7)
     expect(Array.isArray(json.overdueTrend)).toBe(true)
     expect(json.overdueTrend).toHaveLength(7)
+    expect(Array.isArray(json.waterWeather)).toBe(true)
+    expect(json.waterWeather).toHaveLength(7)
   })
 })
 

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -87,7 +87,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 7. Dashboard & Insights (`/dashboard`)
 - [x] Create widgets for completion rate, overdue trends, and streaks
 - [x] Highlight plants needing attention
-- [ ] (Optional) Graph ET₀/weather vs. watering patterns
+- [x] (Optional) Graph ET₀/weather vs. watering patterns
 
 ---
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -70,6 +70,37 @@ export default async function DashboardPage() {
             ))}
           </div>
         </section>
+
+        <section className="rounded-2xl border bg-card text-card-foreground p-6">
+          <h2 className="text-lg font-medium mb-4">Water vs ET₀ (7 days)</h2>
+          <div className="grid grid-cols-7 gap-2">
+            {(stats?.waterWeather || []).map((d: any) => (
+              <div key={d.day} className="flex flex-col items-center gap-2">
+                <div className="flex gap-1 items-end h-24">
+                  <div
+                    className="w-3 rounded-md bg-primary/20"
+                    style={{ height: 4 + d.water * 8 }}
+                    title={`${d.water} waterings`}
+                  />
+                  <div
+                    className="w-3 rounded-md bg-secondary/20"
+                    style={{ height: 4 + d.et0 * 8 }}
+                    title={`ET₀ ${d.et0}`}
+                  />
+                </div>
+                <div className="text-[10px] text-muted-foreground">{d.day.slice(5)}</div>
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-center gap-4 mt-4 text-[10px] text-muted-foreground">
+            <div className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded-sm bg-primary/20" /> Waterings
+            </div>
+            <div className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded-sm bg-secondary/20" /> ET₀
+            </div>
+          </div>
+        </section>
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- add ET₀ vs watering data to dashboard API
- visualize water vs ET₀ trends on dashboard page
- mark dashboard weather graph task as complete

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad12dae8e4832497ade8070881485e