### PR TITLE
Cache weather API responses and verify debounce behavior

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -106,7 +106,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ## 10. Performance & UX Hygiene
 - [x] SSR page shells with suspense for data
-- [ ] Cache weather and debounce species search
+- [x] Cache weather and debounce species search
 - [ ] Apply optimistic updates and ensure accessibility standards
 
 ---

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,14 +1,30 @@
 import { NextResponse } from 'next/server';
 
+type CacheEntry = {
+  lat: string;
+  lon: string;
+  timestamp: number;
+  data: any;
+};
+
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+let cache: CacheEntry | null = null;
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const lat =
-    searchParams.get('lat') ?? process.env.WEATHER_LAT ?? '40.71';
-  const lon =
-    searchParams.get('lon') ?? process.env.WEATHER_LON ?? '-74.01';
+  const lat = searchParams.get('lat') ?? process.env.WEATHER_LAT ?? '40.71';
+  const lon = searchParams.get('lon') ?? process.env.WEATHER_LON ?? '-74.01';
 
-  const url =
-    `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto`;
+  if (
+    cache &&
+    cache.lat === lat &&
+    cache.lon === lon &&
+    Date.now() - cache.timestamp < CACHE_TTL
+  ) {
+    return NextResponse.json(cache.data);
+  }
+
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto`;
 
   const res = await fetch(url);
   if (!res.ok) {
@@ -22,6 +38,8 @@ export async function GET(req: Request) {
     tempMin: daily.temperature_2m_min[idx],
     precipitationChance: daily.precipitation_probability_max[idx],
   }));
+
+  cache = { lat, lon, timestamp: Date.now(), data: days };
   return NextResponse.json(days);
 }
 

--- a/tests/use-debounce.test.ts
+++ b/tests/use-debounce.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from '@/lib/use-debounce';
+import { vi, describe, it, expect } from 'vitest';
+
+describe('useDebounce', () => {
+  it('delays value updates', () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ val }) => useDebounce(val, 200),
+      { initialProps: { val: 'a' } }
+    );
+
+    act(() => {
+      rerender({ val: 'ab' });
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('ab');
+    vi.useRealTimers();
+  });
+});

--- a/tests/weather.api.test.ts
+++ b/tests/weather.api.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from '../src/app/api/weather/route';
+
+// Helper to create Response-like object for fetch spy
+function mockFetch(jsonData: any) {
+  return {
+    ok: true,
+    json: async () => jsonData,
+  } as any;
+}
+
+describe('GET /api/weather', () => {
+  it('caches responses for identical coords', async () => {
+    const mockData = {
+      daily: {
+        time: ['2024-01-01'],
+        temperature_2m_max: [20],
+        temperature_2m_min: [10],
+        precipitation_probability_max: [50],
+      },
+    };
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(mockFetch(mockData));
+
+    const req = new Request('http://localhost/api/weather?lat=1&lon=2');
+    const res1 = await GET(req);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const json1 = await res1.json();
+    expect(json1[0].tempMax).toBe(20);
+
+    const res2 = await GET(req);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const json2 = await res2.json();
+    expect(json2).toEqual(json1);
+
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- cache weather API responses for 30 minutes to reduce external fetches
- mark performance task complete in implementation guide
- add tests covering weather caching and useDebounce hook

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1d5882448324b2b1dacaa464e04c