### PR TITLE
feat: add basic PWA manifest

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -146,7 +146,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 - [ ] Natural-language queries (“How’s Kay doing?”)
 
 ### Mobile Polish & PWA
-- [ ] Add manifest.json + icons
+- [x] Add manifest.json + icons
 - [ ] Configure Next.js PWA plugin
 - [ ] Test on iOS/Android as standalone app
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "Flora",
+  "short_name": "Flora",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#16a34a",
+  "icons": [
+    { "src": "/globe.svg", "sizes": "any", "type": "image/svg+xml" }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
         />
+        <link rel="manifest" href="/manifest.json" />
       </head>
       <body className="flex min-h-screen flex-col bg-background text-foreground">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>


### PR DESCRIPTION
## Summary
- add web app manifest with basic icons for PWA support
- reference manifest from the app layout
- mark manifest task complete in implementation guide
- replace binary icons with existing SVG to avoid unsupported files

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d39c760832482404ba64d5779cb