### PR TITLE
feat: add export endpoint

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -126,7 +126,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ## 13. Next Round of Tasks (Beyond v1)
 
 ### Import / Export
-- [ ] Export plants + events as JSON or CSV
+- [x] Export plants + events as JSON or CSV
 - [ ] Import plants from JSON (validate schema)
 - [ ] Add “Download Backup” & “Restore” buttons in `/dashboard`
 

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { toCsv } from "@/lib/csv";
+
+function supabaseServer() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  if (!url || !key) {
+    throw new Error("Missing SUPABASE env vars. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function GET(req: Request) {
+  try {
+    const supabase = supabaseServer();
+    const { searchParams } = new URL(req.url);
+    const format = searchParams.get("format")?.toLowerCase() || "json";
+
+    const { data: plants, error: plantsError } = await supabase.from("plants").select("*");
+    if (plantsError) {
+      return NextResponse.json({ error: plantsError.message }, { status: 500 });
+    }
+    const { data: events, error: eventsError } = await supabase.from("events").select("*");
+    if (eventsError) {
+      return NextResponse.json({ error: eventsError.message }, { status: 500 });
+    }
+
+    if (format === "csv") {
+      const plantsCsv = toCsv(plants ?? []);
+      const eventsCsv = toCsv(events ?? []);
+      const csv = `plants\n${plantsCsv}\n\nevents\n${eventsCsv}\n`;
+      return new NextResponse(csv, {
+        status: 200,
+        headers: { "Content-Type": "text/csv" },
+      });
+    }
+
+    return NextResponse.json(
+      { plants: plants ?? [], events: events ?? [] },
+      { status: 200 },
+    );
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/tests/export.api.test.ts
+++ b/tests/export.api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => ({
+      select: () => {
+        if (table === "plants") {
+          return Promise.resolve({ data: [{ id: 1, nickname: "Fern" }], error: null });
+        }
+        return Promise.resolve({ data: [{ id: 10, plant_id: 1, type: "water" }], error: null });
+      },
+    }),
+  }),
+}));
+
+describe("GET /api/export", () => {
+  it("returns plants and events in JSON by default", async () => {
+    const { GET } = await import("../src/app/api/export/route");
+    const req = new Request("http://localhost/api/export");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      plants: [{ id: 1, nickname: "Fern" }],
+      events: [{ id: 10, plant_id: 1, type: "water" }],
+    });
+  });
+
+  it("returns CSV when format=csv", async () => {
+    const { GET } = await import("../src/app/api/export/route");
+    const req = new Request("http://localhost/api/export?format=csv");
+    const res = await GET(req);
+    const text = await res.text();
+    expect(res.headers.get("Content-Type")).toBe("text/csv");
+    expect(text).toContain("plants");
+    expect(text).toContain("events");
+    expect(text).toContain("Fern");
+    expect(text).toContain("water");
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/export` endpoint to download plants and events as JSON or CSV
- document completion of export task
- cover export endpoint with tests

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68adac9f1f5c8324a24f213a96da0e64