### PR TITLE
feat: add plants import endpoint

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -127,7 +127,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ### Import / Export
 - [x] Export plants + events as JSON or CSV
-- [ ] Import plants from JSON (validate schema)
+- [x] Import plants from JSON (validate schema)
 - [ ] Add “Download Backup” & “Restore” buttons in `/dashboard`
 
 ### Offline Queue & Sync

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+
+function supabaseServer() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  if (!url || !key) {
+    throw new Error("Missing SUPABASE env vars. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+const plantSchema = z.object({
+  id: z.string().uuid().optional(),
+  room_id: z.number().int().nullable().optional(),
+  user_id: z.string(),
+  nickname: z.string(),
+  species_scientific: z.string(),
+  species_common: z.string().nullable().optional(),
+  pot_size: z.string().nullable().optional(),
+  pot_material: z.string().nullable().optional(),
+  drainage: z.string().nullable().optional(),
+  soil_type: z.string().nullable().optional(),
+  light_level: z.string().nullable().optional(),
+  indoor: z.string().nullable().optional(),
+  humidity: z.string().nullable().optional(),
+  image_url: z.string().nullable().optional(),
+  care_plan: z.any().nullable().optional(),
+  archived: z.boolean().optional(),
+  notifications_muted: z.boolean().optional(),
+  created_at: z.string().optional(),
+});
+
+const eventSchema = z.object({
+  id: z.string().uuid().optional(),
+  plant_id: z.string().uuid(),
+  user_id: z.string(),
+  type: z.string(),
+  note: z.string().nullable().optional(),
+  image_url: z.string().nullable().optional(),
+  public_id: z.string().nullable().optional(),
+  created_at: z.string().optional(),
+});
+
+const backupSchema = z.object({
+  plants: z.array(plantSchema),
+  events: z.array(eventSchema),
+});
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { plants, events } = backupSchema.parse(body);
+
+    const supabase = supabaseServer();
+
+    if (plants.length) {
+      const { error: plantError } = await supabase
+        .from("plants")
+        .upsert(plants, { onConflict: "id" });
+      if (plantError) {
+        return NextResponse.json({ error: plantError.message }, { status: 400 });
+      }
+    }
+
+    if (events.length) {
+      const { error: eventError } = await supabase
+        .from("events")
+        .upsert(events, { onConflict: "id" });
+      if (eventError) {
+        return NextResponse.json({ error: eventError.message }, { status: 400 });
+      }
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (e: unknown) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+    const msg = e instanceof Error ? e.message : "Server error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/tests/import.api.test.ts
+++ b/tests/import.api.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const plantUpsert = vi.fn().mockResolvedValue({ error: null });
+const eventUpsert = vi.fn().mockResolvedValue({ error: null });
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "plants") {
+        return { upsert: plantUpsert };
+      }
+      if (table === "events") {
+        return { upsert: eventUpsert };
+      }
+      return {} as unknown as Record<string, never>;
+    },
+  }),
+}));
+
+describe("POST /api/import", () => {
+  beforeEach(() => {
+    plantUpsert.mockClear();
+    eventUpsert.mockClear();
+  });
+  it("imports plants and events", async () => {
+    const { POST } = await import("../src/app/api/import/route");
+    const payload = {
+      plants: [
+        {
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          user_id: "u1",
+          nickname: "Fern",
+          species_scientific: "Fernae",
+        },
+      ],
+      events: [
+        {
+          plant_id: "123e4567-e89b-12d3-a456-426614174000",
+          user_id: "u1",
+          type: "water",
+        },
+      ],
+    };
+    const req = new Request("http://localhost/api/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(plantUpsert).toHaveBeenCalledWith(payload.plants, { onConflict: "id" });
+    expect(eventUpsert).toHaveBeenCalledWith(payload.events, { onConflict: "id" });
+  });
+
+  it("validates schema and returns 400", async () => {
+    const { POST } = await import("../src/app/api/import/route");
+    const req = new Request("http://localhost/api/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plants: [{}], events: [] }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/import` endpoint to restore plants and events from JSON backups
- validate incoming backup with zod schema and upsert records
- cover import API with tests and mark docs task complete

## Testing
- `pnpm lint`
- `pnpm test tests/import.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adaf2a9f148324be7886ab780e4c66