### PR TITLE
feat: add backup controls to dashboard

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -128,7 +128,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ### Import / Export
 - [x] Export plants + events as JSON or CSV
 - [x] Import plants from JSON (validate schema)
-- [ ] Add “Download Backup” & “Restore” buttons in `/dashboard`
+- [x] Add “Download Backup” & “Restore” buttons in `/dashboard`
 
 ### Offline Queue & Sync
 - [ ] Add `offlineQueue.ts` util (queue failed POSTs to localStorage)

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import DashboardStat from "@/components/DashboardStat"
+import BackupControls from "@/components/BackupControls"
 
 export const dynamic = "force-dynamic"
 
@@ -100,6 +101,11 @@ export default async function DashboardPage() {
               <div className="w-3 h-3 rounded-sm bg-secondary/20" /> ET₀
             </div>
           </div>
+        </section>
+
+        <section className="rounded-2xl border bg-card text-card-foreground p-6">
+          <h2 className="text-lg font-medium mb-4">Backup</h2>
+          <BackupControls />
         </section>
       </div>
     </main>

--- a/src/components/BackupControls.tsx
+++ b/src/components/BackupControls.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { apiFetch } from '@/lib/api';
+
+export default function BackupControls() {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleDownload() {
+    try {
+      const res = await fetch('/api/export');
+      if (!res.ok) throw new Error('Failed to export data');
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'flora-backup.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Export failed';
+      toast.error(msg);
+    }
+  }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const json = JSON.parse(text);
+      await apiFetch('/api/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(json),
+      });
+      toast.success('Backup restored');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Import failed';
+      toast.error(msg);
+    } finally {
+      e.target.value = '';
+    }
+  }
+
+  return (
+    <div className="flex gap-4">
+      <Button onClick={handleDownload}>Download Backup</Button>
+      <Button variant="outline" onClick={() => inputRef.current?.click()}>
+        Restore
+      </Button>
+      <input
+        type="file"
+        accept="application/json"
+        ref={inputRef}
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+}
+

--- a/tests/backupcontrols.test.tsx
+++ b/tests/backupcontrols.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BackupControls from '../src/components/BackupControls';
+
+(globalThis as any).React = React;
+(HTMLAnchorElement.prototype as any).click = vi.fn();
+
+describe('BackupControls', () => {
+  it('requests export on download', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plants: [], events: [] }),
+    });
+    global.fetch = fetchMock as any;
+    (global.URL as any).createObjectURL = vi.fn(() => 'blob:mock');
+    (global.URL as any).revokeObjectURL = vi.fn();
+
+    render(<BackupControls />);
+    const btn = screen.getByText('Download Backup');
+    await fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/export');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow backing up and restoring data via new dashboard controls
- document backup buttons in implementation tasks
- cover export button with unit test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb83fffd4832493a2479960fa1bec