### PR TITLE
feat: add sync status badge for offline queue

### DIFF
--- a/__tests__/sync-status-badge.test.tsx
+++ b/__tests__/sync-status-badge.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import SyncStatusBadge from "@/components/SyncStatusBadge";
+import { queueEvent, QUEUE_KEY } from "@/lib/offlineQueue";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+describe("SyncStatusBadge", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Object.defineProperty(window.navigator, "onLine", {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  it("shows Synced when queue is empty", () => {
+    render(<SyncStatusBadge />);
+    expect(screen.getByText(/synced/i)).toBeInTheDocument();
+  });
+
+  it("shows Pending when there are queued events", () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      value: false,
+      configurable: true,
+    });
+    queueEvent({ plant_id: "1", type: "note", note: "hi" });
+    render(<SyncStatusBadge />);
+    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem(QUEUE_KEY) || "[]")).toHaveLength(1);
+  });
+});

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -131,9 +131,9 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 - [x] Add “Download Backup” & “Restore” buttons in `/dashboard`
 
 ### Offline Queue & Sync
-- [ ] Add `offlineQueue.ts` util (queue failed POSTs to localStorage)
-- [ ] Retry queued events on reconnect
-- [ ] Add status badge for `Synced` vs `Pending`
+- [x] Add `offlineQueue.ts` util (queue failed POSTs to localStorage)
+- [x] Retry queued events on reconnect
+- [x] Add status badge for `Synced` vs `Pending`
 
 ### Photo Gallery Polish
 - [ ] Add carousel with swipe

--- a/src/components/SiteNav.tsx
+++ b/src/components/SiteNav.tsx
@@ -11,6 +11,7 @@ import {
   NavigationMenuLink,
 } from "@/components/ui/navigation-menu";
 import { cn } from "@/lib/utils";
+import SyncStatusBadge from "@/components/SyncStatusBadge";
 
 (globalThis as unknown as { React?: typeof React }).React ??= React;
 
@@ -27,7 +28,7 @@ export default function SiteNav() {
 
   return (
     <>
-      <div className="hidden md:block px-4 md:px-6">
+      <div className="hidden md:flex items-center justify-between px-4 md:px-6">
         <NavigationMenu>
           <NavigationMenuList>
             {links.map(({ href, label }) => (
@@ -48,6 +49,7 @@ export default function SiteNav() {
             ))}
           </NavigationMenuList>
         </NavigationMenu>
+        <SyncStatusBadge />
       </div>
       <nav className="fixed bottom-0 left-0 right-0 z-20 flex justify-around border-t bg-background py-2 md:hidden">
         {links.map(({ href, label, icon: Icon }) => (

--- a/src/components/SyncStatusBadge.tsx
+++ b/src/components/SyncStatusBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { getQueueLength } from "@/lib/offlineQueue";
+
+export default function SyncStatusBadge() {
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    const update = () => setPending(getQueueLength() > 0);
+    update();
+    window.addEventListener("flora:queue:changed", update);
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("flora:queue:changed", update);
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return (
+    <Badge variant={pending ? "destructive" : "secondary"}>
+      {pending ? "Pending" : "Synced"}
+    </Badge>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export { default as EmptyPlantState } from './EmptyPlantState';
 export { default as EmptyTasksState } from './EmptyTasksState';
 export { default as TaskCard } from './TaskCard';
 export { default as TaskSkeleton } from './TaskSkeleton';
+export { default as SyncStatusBadge } from './SyncStatusBadge';

--- a/src/lib/offlineQueue.ts
+++ b/src/lib/offlineQueue.ts
@@ -21,9 +21,18 @@ function saveQueue(queue: EventPayload[]) {
   if (typeof window === 'undefined') return;
   try {
     localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    window.dispatchEvent(
+      new CustomEvent('flora:queue:changed', {
+        detail: { length: queue.length },
+      }),
+    );
   } catch {
     // ignore
   }
+}
+
+export function getQueueLength() {
+  return getQueue().length;
 }
 
 export async function flushQueue() {


### PR DESCRIPTION
## Summary
- add queue change events and helper to offlineQueue
- display sync status badge and wire into top navigation
- document offline queue tasks as complete

## Testing
- `npm test`
- `npm run lint` *(warn: Custom fonts not added in pages/_document.js, unused vars, eslint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68adbeb5a2288324ac986e4e30480bf8