### PR TITLE
feat: add swipeable photo carousel

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -136,7 +136,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 - [x] Add status badge for `Synced` vs `Pending`
 
 ### Photo Gallery Polish
-- [ ] Add carousel with swipe
+- [x] Add carousel with swipe
 - [ ] Support full-screen modal view
 - [ ] Tag photos by event type
 

--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -1,25 +1,64 @@
 'use client';
 
+import { useRef } from 'react';
 import Image from 'next/image';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { CareEvent } from '@/types';
 
 export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const photos = events.filter((e) => e.type === 'photo' && e.image_url);
   if (photos.length === 0) {
     return <p className="text-sm text-muted-foreground">No photos yet.</p>;
   }
+
+  function scrollByDir(dir: number) {
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollBy({
+      left: dir * container.clientWidth,
+      behavior: 'smooth',
+    });
+  }
+
   return (
-    <div className="grid grid-cols-2 gap-3">
-      {photos.map((photo) => (
-        <Image
-          key={photo.id}
-          src={photo.image_url || ''}
-          alt={photo.note ?? 'Photo of plant'}
-          width={300}
-          height={300}
-          className="h-32 w-full rounded-lg object-cover"
-        />
-      ))}
+    <div className="relative" aria-label="Photo gallery">
+      <div
+        ref={containerRef}
+        className="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth touch-pan-x"
+      >
+        {photos.map((photo) => (
+          <div key={photo.id} className="w-full flex-shrink-0 snap-center">
+            <Image
+              src={photo.image_url || ''}
+              alt={photo.note ?? 'Photo of plant'}
+              width={300}
+              height={300}
+              className="h-48 w-full rounded-lg object-cover"
+            />
+          </div>
+        ))}
+      </div>
+      {photos.length > 1 && (
+        <>
+          <button
+            type="button"
+            aria-label="Previous"
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 p-1 shadow"
+            onClick={() => scrollByDir(-1)}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 p-1 shadow"
+            onClick={() => scrollByDir(1)}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/plant/Timeline.tsx
+++ b/src/components/plant/Timeline.tsx
@@ -32,7 +32,7 @@ export function Timeline({ plantId }: { plantId: number }) {
 
   React.useEffect(() => {
     load();
-    const handler = (e: Event | any) => load();
+    const handler = (_e: Event | any) => load();
     window.addEventListener("flora:events:changed", handler as any);
     return () => window.removeEventListener("flora:events:changed", handler as any);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tests/photogallery.test.tsx
+++ b/tests/photogallery.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PhotoGalleryClient from '../src/components/plant/PhotoGalleryClient';
+import type { CareEvent } from '../src/types';
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ComponentProps<'img'>) => <img {...props} alt={props.alt ?? ''} />,
+}));
+
+describe('PhotoGalleryClient', () => {
+  it('renders navigation buttons when multiple photos', () => {
+    const events: CareEvent[] = [
+      { id: '1', type: 'photo', note: null, image_url: 'a.jpg', created_at: '' },
+      { id: '2', type: 'photo', note: null, image_url: 'b.jpg', created_at: '' },
+    ];
+
+    render(<PhotoGalleryClient events={events} />);
+
+    const gallery = screen.getByLabelText('Photo gallery');
+    expect(gallery.querySelector('button[aria-label="Previous"]')).toBeTruthy();
+    expect(gallery.querySelector('button[aria-label="Next"]')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- turn photo gallery into swipeable carousel with left/right controls
- document completion of carousel task
- fix unused handler warning in timeline component

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc1159fac8324b167450f90cc3143