### PR TITLE
Add full-screen photo modal to gallery

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -137,7 +137,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ### Photo Gallery Polish
 - [x] Add carousel with swipe
-- [ ] Support full-screen modal view
+ - [x] Support full-screen modal view
 - [ ] Tag photos by event type
 
 ### Advanced AI Care Coach

--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import Image from 'next/image';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import type { CareEvent } from '@/types';
 
 export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState<{
+    id: string;
+    image_url: string | null;
+    note: string | null;
+  } | null>(null);
   const photos = events.filter((e) => e.type === 'photo' && e.image_url);
   if (photos.length === 0) {
     return <p className="text-sm text-muted-foreground">No photos yet.</p>;
@@ -28,7 +34,13 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
         className="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth touch-pan-x"
       >
         {photos.map((photo) => (
-          <div key={photo.id} className="w-full flex-shrink-0 snap-center">
+          <button
+            key={photo.id}
+            type="button"
+            className="w-full flex-shrink-0 snap-center focus:outline-none"
+            onClick={() => setActive(photo)}
+            aria-label="View photo"
+          >
             <Image
               src={photo.image_url || ''}
               alt={photo.note ?? 'Photo of plant'}
@@ -36,7 +48,7 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
               height={300}
               className="h-48 w-full rounded-lg object-cover"
             />
-          </div>
+          </button>
         ))}
       </div>
       {photos.length > 1 && (
@@ -59,6 +71,33 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
           </button>
         </>
       )}
+
+      <Dialog.Root open={!!active} onOpenChange={(o) => !o && setActive(null)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/80" />
+          <Dialog.Content
+            className="fixed inset-0 flex items-center justify-center p-4"
+          >
+            <Dialog.Title className="sr-only">Full size photo</Dialog.Title>
+            <Dialog.Description className="sr-only">
+              Enlarged view of the selected plant photo
+            </Dialog.Description>
+            {active && (
+              <Image
+                src={active.image_url || ''}
+                alt={active.note ?? 'Photo of plant'}
+                width={1000}
+                height={1000}
+                className="max-h-full w-auto object-contain"
+              />
+            )}
+            <Dialog.Close className="absolute right-4 top-4 text-white">
+              <X className="h-6 w-6" />
+              <span className="sr-only">Close</span>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/tests/photogallery.test.tsx
+++ b/tests/photogallery.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import PhotoGalleryClient from '../src/components/plant/PhotoGalleryClient';
 import type { CareEvent } from '../src/types';
@@ -23,6 +24,20 @@ describe('PhotoGalleryClient', () => {
     const gallery = screen.getByLabelText('Photo gallery');
     expect(gallery.querySelector('button[aria-label="Previous"]')).toBeTruthy();
     expect(gallery.querySelector('button[aria-label="Next"]')).toBeTruthy();
+  });
+
+  it('opens full-screen modal when photo clicked', async () => {
+    const events: CareEvent[] = [
+      { id: '1', type: 'photo', note: null, image_url: 'a.jpg', created_at: '' },
+    ];
+
+    const user = userEvent.setup();
+    render(<PhotoGalleryClient events={events} />);
+
+    await user.click(screen.getByRole('button', { name: /view photo/i }));
+    expect(
+      screen.getByRole('dialog', { name: /full size photo/i })
+    ).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- allow clicking gallery images to open a full-screen dialog
- document task completion for photo modal feature
- test full-screen modal functionality

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc9ea36dc8324ab9138e953732ec1