### PR TITLE
feat: allow tagging plant photos

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -138,7 +138,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ### Photo Gallery Polish
 - [x] Add carousel with swipe
  - [x] Support full-screen modal view
-- [ ] Tag photos by event type
+ - [x] Tag photos by event type
 
 ### Advanced AI Care Coach
 - [ ] Daily digest summarizing all tasks

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: Request) {
     let note: string | null = null;
     let amount: number | null = null;
     let imageUrl: string | null = null;
+    let tag: string | null = null;
     let file: File | null = null;
 
     if (!contentType || !contentType.includes("application/json")) {
@@ -51,6 +52,7 @@ export async function POST(req: Request) {
       plantId = form.get("plant_id")?.toString() || null;
       type = form.get("type")?.toString() || null;
       note = typeof form.get("note") === "string" ? (form.get("note") as string) : null;
+      tag = form.get("tag")?.toString() || null;
       const amt = form.get("amount");
       amount = typeof amt === "string" && amt ? Number(amt) : null;
       const f = form.get("photo");
@@ -60,6 +62,7 @@ export async function POST(req: Request) {
       plantId = body?.plant_id ?? null;
       type = body?.type ?? null;
       note = typeof body?.note === "string" ? body.note : null;
+      tag = typeof body?.tag === "string" ? body.tag : null;
       amount = body?.amount ?? null;
       imageUrl = typeof body?.photoUrl === "string" ? body.photoUrl : null;
     }
@@ -117,6 +120,7 @@ export async function POST(req: Request) {
       image_url: imageUrl,
       public_id: publicId,
       user_id: userId,
+      tag,
     };
 
     const { data, error } = await supabase.from("events").insert(payload).select();

--- a/src/components/AddPhotoForm.tsx
+++ b/src/components/AddPhotoForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { CareEvent } from '@/types';
+import { CARE_EVENT_TYPES, type CareEvent, type CareEventType } from '@/types';
 import { Button } from '@/components/ui/button';
 import {
   Tooltip,
@@ -20,6 +20,7 @@ interface Props {
 export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
+  const [tag, setTag] = useState<CareEventType>('water');
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -32,12 +33,14 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
       note: null,
       image_url: null,
       created_at: new Date().toISOString(),
+      tag,
     };
     onAdd(optimistic);
     const formData = new FormData();
     formData.append('plant_id', plantId);
     formData.append('type', 'photo');
     formData.append('photo', file);
+    if (tag) formData.append('tag', tag);
     setFile(null);
     (e.target as HTMLFormElement).reset();
     try {
@@ -64,6 +67,21 @@ export default function AddPhotoForm({ plantId, onAdd, onReplace }: Props) {
         disabled={saving}
         onChange={(e) => setFile(e.target.files?.[0] ?? null)}
       />
+      <label className="text-sm">
+        Tag
+        <select
+          value={tag}
+          onChange={(e) => setTag(e.target.value as CareEventType)}
+          disabled={saving}
+          className="mt-1 rounded-md border px-2 py-1"
+        >
+          {CARE_EVENT_TYPES.filter((t) => t !== 'photo').map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -41,13 +41,20 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
             onClick={() => setActive(photo)}
             aria-label="View photo"
           >
-            <Image
-              src={photo.image_url || ''}
-              alt={photo.note ?? 'Photo of plant'}
-              width={300}
-              height={300}
-              className="h-48 w-full rounded-lg object-cover"
-            />
+            <div className="relative">
+              <Image
+                src={photo.image_url || ''}
+                alt={photo.note ?? 'Photo of plant'}
+                width={300}
+                height={300}
+                className="h-48 w-full rounded-lg object-cover"
+              />
+              {photo.tag && (
+                <span className="absolute left-2 top-2 rounded bg-background/80 px-2 text-xs capitalize">
+                  {photo.tag}
+                </span>
+              )}
+            </div>
           </button>
         ))}
       </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,5 @@ export interface CareEvent {
   note: string | null;
   image_url: string | null;
   created_at: string;
+  tag?: CareEventType | null;
 }

--- a/tests/events.api.test.ts
+++ b/tests/events.api.test.ts
@@ -183,6 +183,22 @@ describe("POST /api/events", () => {
     expect(res.status).toBe(200);
     expect(updatedImageUrl).toBe("https://example.com/uploaded.jpg");
   });
+
+  it("persists tag for photo events", async () => {
+    const { POST } = await import("../src/app/api/events/route");
+    const form = new FormData();
+    form.set("plant_id", "4aa97bee-71f1-428e-843b-4c3c77493994");
+    form.set("type", "photo");
+    form.set("tag", "water");
+    const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
+    form.set("photo", file);
+    const req = new Request("http://localhost", { method: "POST" }) as Request & {
+      formData: () => Promise<FormData>;
+    };
+    req.formData = () => Promise.resolve(form);
+    await POST(req);
+    expect(insertedValues).toMatchObject({ tag: "water" });
+  });
 });
 
 describe("DELETE /api/events/[id]", () => {

--- a/tests/photogallery.test.tsx
+++ b/tests/photogallery.test.tsx
@@ -39,5 +39,21 @@ describe('PhotoGalleryClient', () => {
       screen.getByRole('dialog', { name: /full size photo/i })
     ).toBeTruthy();
   });
+
+  it('shows tag for photo event', () => {
+    const events: CareEvent[] = [
+      {
+        id: '1',
+        type: 'photo',
+        note: null,
+        image_url: 'a.jpg',
+        created_at: '',
+        tag: 'water',
+      },
+    ];
+
+    render(<PhotoGalleryClient events={events} />);
+    expect(screen.getByText('water')).toBeTruthy();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add tag selection when uploading plant photos
- store photo tags in events API and render tag badges in gallery
- document task completion and cover with tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcd1046408324af3c45db491be545