### PR TITLE
feat: add daily task digest API route

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -141,9 +141,9 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
  - [x] Tag photos by event type
 
 ### Advanced AI Care Coach
-- [ ] Daily digest summarizing all tasks
-- [ ] Seasonal adjustments (light/humidity)
-- [ ] Natural-language queries (“How’s Kay doing?”)
+ - [x] Daily digest summarizing all tasks
+  - [ ] Seasonal adjustments (light/humidity)
+  - [ ] Natural-language queries (“How’s Kay doing?”)
 
 ### Mobile Polish & PWA
 - [x] Add manifest.json + icons

--- a/src/app/api/notifications/digest/route.ts
+++ b/src/app/api/notifications/digest/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getCurrentUserId } from "@/lib/auth";
+
+export async function GET(req: Request) {
+  try {
+    const userId = await getCurrentUserId();
+    const today = new Date().toISOString().slice(0, 10);
+    const { data: tasks, error } = await supabaseAdmin
+      .from("tasks")
+      .select("id, plant_id, type, due_date")
+      .eq("user_id", userId)
+      .is("completed_at", null)
+      .lte("due_date", today);
+    if (error) throw error;
+
+    const list = tasks || [];
+    const count = list.length;
+    const summary =
+      count > 0
+        ? `You have ${count} task${count === 1 ? "" : "s"} due or overdue today.`
+        : "You're all caught up!";
+
+    return NextResponse.json({ ok: true, summary, tasks: list });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Server error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/tests/notifications.digest.api.test.ts
+++ b/tests/notifications.digest.api.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+const today = new Date().toISOString().slice(0, 10);
+const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: () => Promise.resolve("user-123"),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          is: () => ({
+            lte: () =>
+              Promise.resolve({
+                data: [
+                  { id: "1", plant_id: "p1", type: "water", due_date: today },
+                  { id: "2", plant_id: "p2", type: "fertilize", due_date: yesterday },
+                ],
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+describe("GET /api/notifications/digest", () => {
+  it("summarizes due tasks", async () => {
+    const { GET } = await import("../src/app/api/notifications/digest/route");
+    const req = new Request("http://localhost/api/notifications/digest");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: true,
+      summary: "You have 2 tasks due or overdue today.",
+      tasks: [
+        { id: "1", plant_id: "p1", type: "water", due_date: today },
+        { id: "2", plant_id: "p2", type: "fertilize", due_date: yesterday },
+      ],
+    });
+  });
+});
+
+export {};


### PR DESCRIPTION
## Summary
- implement daily digest endpoint for pending tasks
- document completion of daily digest task
- test notification digest endpoint

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68add494dca08324885c133511de9b9c