### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test
+      - name: E2E
+        run: pnpm e2e

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -151,7 +151,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 - [ ] Test on iOS/Android as standalone app
 
 ### CI / CD Automation
-- [ ] GitHub Actions: run `pnpm lint`, `pnpm test`, and `pnpm e2e`
+- [x] GitHub Actions: run `pnpm lint`, `pnpm test`, and `pnpm e2e`
 - [ ] Preview deployments on Vercel
 - [ ] Add coverage reports
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "e2e": "vitest run tests",
     "db:seed": "prisma db seed",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pnpm lint/test/e2e
- add e2e script to package.json
- mark CI task complete in implementation roadmap

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected "spy" to be called 1 times, but got 0 times)*
- `pnpm e2e` *(fails: expected "spy" to be called 1 times, but got 0 times)*

------
https://chatgpt.com/codex/tasks/task_e_68ade51019b883248f2c80e64c664698