### PR TITLE
Add test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Lint
         run: pnpm lint
       - name: Test
-        run: pnpm test
+        run: pnpm test:coverage
       - name: E2E
         run: pnpm e2e

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -153,7 +153,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ### CI / CD Automation
 - [x] GitHub Actions: run `pnpm lint`, `pnpm test`, and `pnpm e2e`
 - [ ] Preview deployments on Vercel
-- [ ] Add coverage reports
+- [x] Add coverage reports
 
 ### Extended Insights
 - [ ] Chart watering vs weather (ET₀ correlation)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:seed": "prisma db seed",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
     "reminders:send": "ts-node scripts/send-reminders.ts"
   },
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config"
+import { defineConfig, coverageConfigDefaults } from "vitest/config"
 import path from "path"
 
 export default defineConfig({
@@ -7,6 +7,12 @@ export default defineConfig({
     setupFiles: ["./test/setup.ts"],
     globals: true,
     include: ["__tests__/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      reportsDirectory: "./coverage",
+      exclude: [...coverageConfigDefaults.exclude, "test/setup.ts"],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- enable coverage reporting in Vitest config
- expose `test:coverage` script and run coverage in CI
- mark coverage task complete in docs

## Testing
- `pnpm lint`
- `pnpm test:coverage` *(fails: expected "spy" to be called 1 times, but got 0 times)*

------
https://chatgpt.com/codex/tasks/task_e_68adeaf119648324a112738eceb89b98