### PR TITLE
Add Vercel preview deployment workflow

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,32 @@
+name: Vercel Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Deploy to Vercel
+        run: |
+          npm i -g vercel@latest
+          vercel pull --yes --environment=preview --token $VERCEL_TOKEN
+          vercel build --token $VERCEL_TOKEN
+          vercel deploy --prebuilt --token $VERCEL_TOKEN

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -152,7 +152,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 
 ### CI / CD Automation
 - [x] GitHub Actions: run `pnpm lint`, `pnpm test`, and `pnpm e2e`
-- [ ] Preview deployments on Vercel
+- [x] Preview deployments on Vercel
 - [x] Add coverage reports
 
 ### Extended Insights


### PR DESCRIPTION
## Summary
- enable Vercel preview deployments via GitHub Actions
- mark preview deployment task as complete in implementation guide

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected "spy" to be called 1 times, but got 0 times)*

------
https://chatgpt.com/codex/tasks/task_e_68adebd151cc83249fe3bc59942a4a84