### PR TITLE
feat: highlight neglected plants on dashboard

### DIFF
--- a/__tests__/dashboard.api.test.ts
+++ b/__tests__/dashboard.api.test.ts
@@ -12,8 +12,9 @@ vi.mock("@supabase/supabase-js", () => {
     { id: 3, created_at: "2025-01-06T09:00:00Z", plant_id: 2, type: "fertilize" },
   ]
   const plants = [
-    { id: 1, name: "Aloe" },
-    { id: 2, name: "Fern" },
+    { id: 1, name: "Aloe", created_at: "2025-01-01" },
+    { id: 2, name: "Fern", created_at: "2025-01-05" },
+    { id: 3, name: "Cactus", created_at: "2024-01-01" },
   ]
   const tasks = [
     { id: 1, plant_id: 1, type: "water", due_date: "2025-01-07", completed_at: null },
@@ -93,7 +94,7 @@ describe("/api/dashboard", () => {
     expect(json).toMatchObject({
       completion: 100,
       totalDone: 3,
-      plants: 2,
+      plants: 3,
       streak: 3,
     })
     expect(json.attention).toHaveLength(1)
@@ -104,6 +105,9 @@ describe("/api/dashboard", () => {
     expect(json.overdueTrend).toHaveLength(7)
     expect(Array.isArray(json.waterWeather)).toBe(true)
     expect(json.waterWeather).toHaveLength(7)
+    expect(Array.isArray(json.neglected)).toBe(true)
+    expect(json.neglected[0].plantName).toBe("Cactus")
+    expect(json.neglected[0].days).toBeGreaterThan(300)
   })
 })
 

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -158,6 +158,6 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ### Extended Insights
 - [ ] Chart watering vs weather (ET₀ correlation)
 - [ ] Show longest streaks per plant
-- [ ] Highlight neglected plants
+ - [x] Highlight neglected plants
 
 ---

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -47,6 +47,21 @@ export default async function DashboardPage() {
             <p className="text-sm text-muted-foreground">All plants are happy 🌿</p>
           )}
         </section>
+        <section className="rounded-2xl border bg-card text-card-foreground p-6">
+          <h2 className="text-lg font-medium mb-4">Neglected Plants</h2>
+          {stats?.neglected?.length ? (
+            <ul className="space-y-3">
+              {stats.neglected.map((p: any) => (
+                <li key={p.id} className="flex items-center justify-between">
+                  <div className="font-medium">{p.plantName}</div>
+                  <div className="text-sm text-muted-foreground">{p.days}d</div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No neglected plants 🎉</p>
+          )}
+        </section>
 
         <section className="rounded-2xl border bg-card text-card-foreground p-6">
           <h2 className="text-lg font-medium mb-4">Overdue Trend (7 days)</h2>


### PR DESCRIPTION
## Summary
- compute long-neglected plants in dashboard API and expose in stats
- surface neglected plants section on dashboard page
- document task completion for highlighting neglected plants
- test dashboard API neglected plant output

## Testing
- `pnpm lint`
- `pnpm test` *(fails: AddNoteForm disables submit while posting)*
- `pnpm test __tests__/dashboard.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adf2feffbc8324a2646dfe0084b069