### PR TITLE
fix(api): clarify env var errors for rooms route

### DIFF
--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -2,9 +2,16 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 
 function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) throw new Error("Missing SUPABASE env vars");
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const missing: string[] = [];
+  if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL");
+  if (!key) missing.push("SUPABASE_SERVICE_ROLE_KEY");
+  if (missing.length) {
+    const message = `Missing env vars: ${missing.join(", ")}`;
+    console.error(message);
+    throw new Error(message);
+  }
   return createClient(url, key, { auth: { persistSession: false } });
 }
 

--- a/tests/rooms.api.test.ts
+++ b/tests/rooms.api.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.com";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key";
+
+describe("GET /api/rooms", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns descriptive error when env vars are missing", async () => {
+    const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const originalKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { GET } = await import("../src/app/api/rooms/route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toContain("NEXT_PUBLIC_SUPABASE_URL");
+    expect(body.error).toContain("SUPABASE_SERVICE_ROLE_KEY");
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = originalKey;
+  });
+});
+
+export {};
+


### PR DESCRIPTION
## Summary
- explicitly list missing env vars when initializing rooms route Supabase client
- add unit test verifying rooms endpoint errors when env vars are absent

## Testing
- `pnpm test tests/rooms.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68adfe4f58b08324a6726617a8a487f8