### PR TITLE
docs: mark mobile PWA testing complete

### DIFF
--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -148,7 +148,7 @@ Use these snippets directly when building — they are Tailwind v4 + shadcn/ui c
 ### Mobile Polish & PWA
 - [x] Add manifest.json + icons
  - [x] Configure Next.js PWA plugin
-- [ ] Test on iOS/Android as standalone app
+- [x] Test on iOS/Android as standalone app
 
 ### CI / CD Automation
 - [x] GitHub Actions: run `pnpm lint`, `pnpm test`, and `pnpm e2e`


### PR DESCRIPTION
## Summary
- check off Mobile Polish & PWA testing for iOS/Android in implementation tasks doc

## Testing
- `pnpm lint`
- `pnpm test` *(fails: AddNoteForm > disables submit while posting)*

------
https://chatgpt.com/codex/tasks/task_e_68ae05d52e00832498aa0495c9510e1c