### PR TITLE
test: add export api coverage

### DIFF
--- a/__tests__/export.api.test.ts
+++ b/__tests__/export.api.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET as ExportGET } from "@/app/api/export/route";
+
+vi.mock("@supabase/supabase-js", () => {
+  function createClient(_url: string, _key: string) {
+    return {
+      from(table: string) {
+        if (table === "plants") {
+          return {
+            select() {
+              return { data: [{ id: "1", nickname: "Aloe" }], error: null };
+            },
+          };
+        }
+        if (table === "events") {
+          return {
+            select() {
+              return { data: [{ id: "1", plant_id: "1", type: "water" }], error: null };
+            },
+          };
+        }
+        throw new Error("Unexpected table: " + table);
+      },
+    };
+  }
+  return { createClient };
+});
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "test_key";
+});
+
+describe("/api/export route", () => {
+  it("returns plants and events as JSON by default", async () => {
+    const req = new Request("http://localhost/api/export");
+    const res = await ExportGET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      plants: [{ id: "1", nickname: "Aloe" }],
+      events: [{ id: "1", plant_id: "1", type: "water" }],
+    });
+  });
+
+  it("returns CSV when format=csv", async () => {
+    const req = new Request("http://localhost/api/export?format=csv");
+    const res = await ExportGET(req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/csv");
+    const text = await res.text();
+    expect(text).toContain("plants");
+    expect(text).toContain("events");
+    expect(text).toContain("Aloe");
+    expect(text).toContain("water");
+  });
+});

--- a/tests/addnoteform.test.tsx
+++ b/tests/addnoteform.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderToString } from "react-dom/server";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AddNoteForm from "../src/components/AddNoteForm";
 
 (globalThis as unknown as { React: typeof React }).React = React;
@@ -23,7 +23,7 @@ describe("AddNoteForm", () => {
     expect(html).toContain("Add Note");
   });
 
-  it("disables submit while posting", () => {
+  it("disables submit while posting", async () => {
     let resolveFetch: (value: unknown) => void = () => undefined;
     vi.stubGlobal(
       "fetch",
@@ -41,7 +41,7 @@ describe("AddNoteForm", () => {
     fireEvent.click(button);
     expect(button).toBeDisabled();
     fireEvent.click(button);
-    expect((globalThis.fetch as any)).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect((globalThis.fetch as any)).toHaveBeenCalledTimes(1));
     resolveFetch({ ok: true, json: () => Promise.resolve({}) });
   });
 });


### PR DESCRIPTION
## Summary
- add tests ensuring `/api/export` returns JSON and CSV data
- fix asynchronous handling in add note form test

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae07aee0848324aae920fb0b19ec38