### PR TITLE
feat: enable single-user mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+# App runs in single-user mode; no additional auth variables required.
 
 # OpenAI
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -87,10 +87,13 @@ Flora creates personalized care plans and adapts them to your environment.
 ## 🗃️ Database
 
 All schema, policies, and seed data live as SQL in [`/supabase`](./supabase).
+The project is configured for **single-user** mode: every table defaults its
+`user_id` column to `flora-single-user`, and row‑level security policies allow
+open access. No authentication setup is required.
 
-- `supabase/migrations/20250825045101_rooms_events.sql` – rooms and events tables with RLS policies
-- `plants.sql` – plants and species tables with RLS policies
-- `tasks.sql` – care task table and policies
+- `supabase/migrations/20250825045101_rooms_events.sql` – rooms and events tables
+- `plants.sql` – plants and species tables
+- `tasks.sql` – care task table
 - `analytics.sql` – analytics events table
 - `sample_data.sql` – optional seed data for plants and tasks
 
@@ -98,7 +101,10 @@ All schema, policies, and seed data live as SQL in [`/supabase`](./supabase).
 
 ## 📦 Setup
 
-Copy `.env.example` to `.env.local` and fill in your Supabase, OpenAI (optional), Cloudinary, and optional auth credentials. Without an `OPENAI_API_KEY`, species suggestions and other AI features are disabled.
+Copy `.env.example` to `.env.local` and fill in your Supabase and optional API keys.
+This project runs in **single-user** mode—authentication is not required and the
+seed data is immediately visible. Without an `OPENAI_API_KEY`, species
+suggestions and other AI features are disabled.
 
 ```bash
 git clone https://github.com/osmond/flora.git
@@ -109,9 +115,11 @@ cp .env.example .env.local  # Fill in your keys
 
 # connect Supabase CLI (first time only)
 supabase login
-supabase link --project-ref suyojlyvriuqchonmpjt
+# link to your own project or start a local instance
+supabase link --project-ref <your_project_ref>  # or run `supabase start`
 
-# apply schema in order using psql
+# use psql to apply schema in order (safe to re-run)
+export DATABASE_URL="postgresql://postgres:<password>@db.<project_ref>.supabase.co:5432/postgres"  # use local string from `supabase start` if running locally
 psql "$DATABASE_URL" -f supabase/migrations/20250825045101_rooms_events.sql
 psql "$DATABASE_URL" -f supabase/plants.sql
 psql "$DATABASE_URL" -f supabase/tasks.sql

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,18 +1,15 @@
 import { headers } from "next/headers";
 
 /**
- * Returns the identifier of the currently authenticated user.
+ * Returns the identifier of the current user.
  *
- * The ID is extracted from the `x-user-id` header which is expected to be
- * populated by upstream authentication middleware. An error is thrown when the
- * header is missing to signal unauthenticated access.
+ * In single-user mode, authentication is optional. If the `x-user-id` header
+ * is missing, a default value of `flora-single-user` is returned so that the
+ * app can operate without an auth provider.
  */
 export async function getCurrentUserId(): Promise<string> {
   const headerList = await headers();
   const userId = headerList.get("x-user-id");
-  if (!userId) {
-    throw new Error("Unauthorized");
-  }
-  return userId;
+  return userId ?? "flora-single-user";
 }
 

--- a/supabase/analytics.sql
+++ b/supabase/analytics.sql
@@ -4,18 +4,22 @@ create extension if not exists pgcrypto;
 
 create table if not exists public.analytics_events (
   id uuid primary key default gen_random_uuid(),
-  user_id text not null,
+  user_id text not null default 'flora-single-user',
   type text not null,
   payload jsonb,
   created_at timestamptz default now()
 );
 
+alter table if exists public.analytics_events
+  add column if not exists user_id text not null default 'flora-single-user';
+
 alter table public.analytics_events enable row level security;
 
 drop policy if exists "user read analytics_events" on public.analytics_events;
-create policy "user read analytics_events" on public.analytics_events
-  for select using (auth.uid()::text = user_id);
-
 drop policy if exists "user insert analytics_events" on public.analytics_events;
-create policy "user insert analytics_events" on public.analytics_events
-  for insert with check (auth.uid()::text = user_id);
+
+create policy "read analytics_events" on public.analytics_events
+  for select using (true);
+
+create policy "insert analytics_events" on public.analytics_events
+  for insert with check (true);

--- a/supabase/migrations/20250825045101_rooms_events.sql
+++ b/supabase/migrations/20250825045101_rooms_events.sql
@@ -22,13 +22,15 @@ create extension if not exists pgcrypto;
 create table if not exists public.events (
   id uuid primary key default gen_random_uuid(),
   plant_id uuid references public.plants(id) on delete cascade,
-  user_id text not null,
+  user_id text not null default 'flora-single-user',
   type text not null,
   note text,
   image_url text,
   public_id text,
   created_at timestamptz default now()
 );
+
+alter table if exists public.events add column if not exists user_id text not null default 'flora-single-user';
 
 alter table public.events enable row level security;
 
@@ -39,17 +41,17 @@ drop policy if exists "user insert events" on public.events;
 drop policy if exists "user update events" on public.events;
 drop policy if exists "user delete events" on public.events;
 
-create policy "user read events" on public.events
-  for select using (auth.uid()::text = user_id);
+create policy "read events" on public.events
+  for select using (true);
 
-create policy "user insert events" on public.events
-  for insert with check (auth.uid()::text = user_id);
+create policy "insert events" on public.events
+  for insert with check (true);
 
-create policy "user update events" on public.events
-  for update using (auth.uid()::text = user_id);
+create policy "update events" on public.events
+  for update using (true);
 
-create policy "user delete events" on public.events
-  for delete using (auth.uid()::text = user_id);
+create policy "delete events" on public.events
+  for delete using (true);
 
 -- Helpful indexes
 create index if not exists idx_events_plant_created on public.events(plant_id, created_at desc);

--- a/supabase/plants.sql
+++ b/supabase/plants.sql
@@ -58,11 +58,10 @@ create table if not exists public.species (
   created_at timestamptz default now()
 );
 
--- Row Level Security
 alter table public.plants enable row level security;
 alter table public.species enable row level security;
 
--- Policies: user-specific access to plants
+-- Policies: open access for single-user mode
 drop policy if exists "public read plants" on public.plants;
 drop policy if exists "public write plants" on public.plants;
 drop policy if exists "user read plants" on public.plants;
@@ -70,17 +69,17 @@ drop policy if exists "user insert plants" on public.plants;
 drop policy if exists "user update plants" on public.plants;
 drop policy if exists "user delete plants" on public.plants;
 
-create policy "user read plants" on public.plants
-  for select using (auth.uid()::text = user_id);
+create policy "read plants" on public.plants
+  for select using (true);
 
-create policy "user insert plants" on public.plants
-  for insert with check (auth.uid()::text = user_id);
+create policy "insert plants" on public.plants
+  for insert with check (true);
 
-create policy "user update plants" on public.plants
-  for update using (auth.uid()::text = user_id);
+create policy "update plants" on public.plants
+  for update using (true);
 
-create policy "user delete plants" on public.plants
-  for delete using (auth.uid()::text = user_id);
+create policy "delete plants" on public.plants
+  for delete using (true);
 
 -- Species remain open for reads/writes
 drop policy if exists "public read species" on public.species;

--- a/supabase/tasks.sql
+++ b/supabase/tasks.sql
@@ -19,7 +19,7 @@ alter table public.tasks enable row level security;
 alter table if exists public.tasks add column if not exists user_id text not null default 'flora-single-user';
 alter table if exists public.tasks add column if not exists snooze_reason text;
 
--- Policies: user-specific access to tasks
+-- Policies: open access for single-user mode
 drop policy if exists "public read tasks" on public.tasks;
 drop policy if exists "public write tasks" on public.tasks;
 drop policy if exists "user read tasks" on public.tasks;
@@ -27,14 +27,14 @@ drop policy if exists "user insert tasks" on public.tasks;
 drop policy if exists "user update tasks" on public.tasks;
 drop policy if exists "user delete tasks" on public.tasks;
 
-create policy "user read tasks" on public.tasks
-  for select using (auth.uid()::text = user_id);
+create policy "read tasks" on public.tasks
+  for select using (true);
 
-create policy "user insert tasks" on public.tasks
-  for insert with check (auth.uid()::text = user_id);
+create policy "insert tasks" on public.tasks
+  for insert with check (true);
 
-create policy "user update tasks" on public.tasks
-  for update using (auth.uid()::text = user_id);
+create policy "update tasks" on public.tasks
+  for update using (true);
 
-create policy "user delete tasks" on public.tasks
-  for delete using (auth.uid()::text = user_id);
+create policy "delete tasks" on public.tasks
+  for delete using (true);


### PR DESCRIPTION
## Summary
- open Supabase policies and default `user_id` to `flora-single-user`
- treat missing auth headers as the single user
- clarify single-user setup in README and env example

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb8fb043c83248e1bb3e88a952c33