### PR TITLE
Refactor quick add to use Form components

### DIFF
--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import * as React from "react";
+import { useForm } from "react-hook-form";
+import { Button, Input, Form, FormField } from "@/components/ui";
 import { queueEvent, type EventPayload } from "@/lib/offlineQueue";
 
 type Props = { plantId: string };
 
 export function EventQuickAdd({ plantId }: Props) {
-  const [note, setNote] = React.useState("");
   const [loading, setLoading] = React.useState(false);
+  const form = useForm<{ note: string }>({
+    defaultValues: { note: "" },
+  });
 
   async function add(type: "water" | "fertilize" | "note") {
     if (loading) return; // prevent duplicate submissions
 
+    const note = form.getValues("note");
     const payload: EventPayload = { plant_id: plantId, type } as EventPayload;
     if (type === "note" && note.trim()) payload.note = note.trim();
 
@@ -23,7 +28,7 @@ export function EventQuickAdd({ plantId }: Props) {
         body: JSON.stringify(payload),
       });
       if (res.ok) {
-        setNote("");
+        form.reset({ note: "" });
         // Consumers should refetch timeline; emit custom event
         window.dispatchEvent(
           new CustomEvent("flora:events:changed", { detail: { plantId } }),
@@ -39,41 +44,51 @@ export function EventQuickAdd({ plantId }: Props) {
   }
 
   return (
-    <div id="log-event" className="rounded-xl border bg-card p-4 space-y-3">
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={() => add("water")}
-          disabled={loading}
-          className="h-9 rounded-md bg-primary px-3 text-sm text-primary-foreground disabled:opacity-50"
-        >
-          Watered
-        </button>
-        <button
-          type="button"
-          onClick={() => add("fertilize")}
-          disabled={loading}
-          className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
-        >
-          Fertilized
-        </button>
+    <Form {...form}>
+      <div id="log-event" className="rounded-xl border bg-card p-4 space-y-3">
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            onClick={() => add("water")}
+            disabled={loading}
+            variant="default"
+            size="sm"
+          >
+            Watered
+          </Button>
+          <Button
+            type="button"
+            onClick={() => add("fertilize")}
+            disabled={loading}
+            variant="outline"
+            size="sm"
+          >
+            Fertilized
+          </Button>
+        </div>
+        <div className="flex gap-2">
+          <FormField
+            control={form.control}
+            name="note"
+            render={({ field }) => (
+              <Input
+                {...field}
+                placeholder="Quick note…"
+                className="h-9 flex-1"
+              />
+            )}
+          />
+          <Button
+            type="button"
+            onClick={() => add("note")}
+            disabled={loading}
+            variant="outline"
+            size="sm"
+          >
+            Add note
+          </Button>
+        </div>
       </div>
-      <div className="flex gap-2">
-        <input
-          className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
-          placeholder="Quick note…"
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-        />
-        <button
-          type="button"
-          onClick={() => add("note")}
-          disabled={loading}
-          className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
-        >
-          Add note
-        </button>
-      </div>
-    </div>
+    </Form>
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+export { Button } from "./button";
+export { Input } from "./input";
+export { Form, FormField } from "./form";


### PR DESCRIPTION
## Summary
- use `react-hook-form` for quick note events
- replace raw HTML buttons and input with UI `Button`/`Input` components
- add UI barrel to export common primitives

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae200c6b208324a4ee781215a5421a