### PR TITLE
refactor: use shadcn dialog and button components

### DIFF
--- a/src/app/plants/PlantList.tsx
+++ b/src/app/plants/PlantList.tsx
@@ -2,8 +2,9 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { PlantCard } from '@/components';
-import Image from "next/image";
+import { Button } from '@/components/ui/button';
 
 interface Plant {
   id: string;
@@ -29,20 +30,22 @@ export default function PlantList({ plants }: { plants: Plant[] }) {
   return (
     <div>
       <div className="mb-4 flex justify-end gap-3">
-        <button
+        <Button
           aria-label="Grid view"
           onClick={() => setView('grid')}
-          className={`rounded-lg px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'grid' ? 'bg-muted' : ''}`}
+          variant={view === 'grid' ? 'secondary' : 'outline'}
+          size="sm"
         >
           Grid
-        </button>
-        <button
+        </Button>
+        <Button
           aria-label="List view"
           onClick={() => setView('list')}
-          className={`rounded-lg px-4 py-2 focus:ring-2 focus:ring-primary ${view === 'list' ? 'bg-muted' : ''}`}
+          variant={view === 'list' ? 'secondary' : 'outline'}
+          size="sm"
         >
           List
-        </button>
+        </Button>
       </div>
       {Object.entries(grouped).map(([roomName, roomPlants]) => (
         <section key={roomName} className="mb-8">

--- a/src/components/plant/EventQuickAdd.tsx
+++ b/src/components/plant/EventQuickAdd.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { queueEvent, type EventPayload } from "@/lib/offlineQueue";
+import { Button } from "@/components/ui/button";
 
 type Props = { plantId: string };
 
@@ -41,22 +42,23 @@ export function EventQuickAdd({ plantId }: Props) {
   return (
     <div id="log-event" className="rounded-xl border bg-card p-4 space-y-3">
       <div className="flex gap-2">
-        <button
+        <Button
           type="button"
           onClick={() => add("water")}
           disabled={loading}
-          className="h-9 rounded-md bg-primary px-3 text-sm text-primary-foreground disabled:opacity-50"
+          size="sm"
         >
           Watered
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
           onClick={() => add("fertilize")}
           disabled={loading}
-          className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
+          variant="outline"
+          size="sm"
         >
           Fertilized
-        </button>
+        </Button>
       </div>
       <div className="flex gap-2">
         <input
@@ -65,14 +67,15 @@ export function EventQuickAdd({ plantId }: Props) {
           value={note}
           onChange={(e) => setNote(e.target.value)}
         />
-        <button
+        <Button
           type="button"
           onClick={() => add("note")}
           disabled={loading}
-          className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
+          variant="outline"
+          size="sm"
         >
           Add note
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -2,8 +2,9 @@
 
 import { useRef, useState } from 'react';
 import Image from 'next/image';
-import * as Dialog from '@radix-ui/react-dialog';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 import type { CareEvent } from '@/types';
 
 export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) {
@@ -34,10 +35,11 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
         className="flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth touch-pan-x"
       >
         {photos.map((photo) => (
-          <button
+          <Button
             key={photo.id}
             type="button"
-            className="w-full flex-shrink-0 snap-center focus:outline-none"
+            variant="ghost"
+            className="h-auto w-full flex-shrink-0 snap-center p-0"
             onClick={() => setActive(photo)}
             aria-label="View photo"
           >
@@ -55,56 +57,55 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
                 </span>
               )}
             </div>
-          </button>
+          </Button>
         ))}
       </div>
       {photos.length > 1 && (
         <>
-          <button
+          <Button
             type="button"
             aria-label="Previous"
-            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 p-1 shadow"
+            variant="ghost"
+            size="icon"
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 shadow"
             onClick={() => scrollByDir(-1)}
           >
             <ChevronLeft className="h-4 w-4" />
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             aria-label="Next"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 p-1 shadow"
+            variant="ghost"
+            size="icon"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 shadow"
             onClick={() => scrollByDir(1)}
           >
             <ChevronRight className="h-4 w-4" />
-          </button>
+          </Button>
         </>
       )}
 
-      <Dialog.Root open={!!active} onOpenChange={(o) => !o && setActive(null)}>
-        <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 bg-black/80" />
-          <Dialog.Content
-            className="fixed inset-0 flex items-center justify-center p-4"
-          >
-            <Dialog.Title className="sr-only">Full size photo</Dialog.Title>
-            <Dialog.Description className="sr-only">
-              Enlarged view of the selected plant photo
-            </Dialog.Description>
-            {active && (
-              <Image
-                src={active.image_url || ''}
-                alt={active.note ?? 'Photo of plant'}
-                width={1000}
-                height={1000}
-                className="max-h-full w-auto object-contain"
-              />
-            )}
-            <Dialog.Close className="absolute right-4 top-4 text-white">
-              <X className="h-6 w-6" />
-              <span className="sr-only">Close</span>
-            </Dialog.Close>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      <Dialog open={!!active} onOpenChange={(o) => !o && setActive(null)}>
+        <DialogContent className="h-full w-full max-w-full flex items-center justify-center p-4 bg-transparent border-0 shadow-none">
+          <DialogTitle className="sr-only">Full size photo</DialogTitle>
+          <DialogDescription className="sr-only">
+            Enlarged view of the selected plant photo
+          </DialogDescription>
+          {active && (
+            <Image
+              src={active.image_url || ''}
+              alt={active.note ?? 'Photo of plant'}
+              width={1000}
+              height={1000}
+              className="max-h-full w-auto object-contain"
+            />
+          )}
+          <DialogClose className="absolute right-4 top-4 text-white">
+            <X className="h-6 w-6" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const DialogClose = DialogPrimitive.Close
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+}


### PR DESCRIPTION
## Summary
- replace Radix dialog usage with shadcn dialog components
- refactor buttons to use shared Button component with variants
- add reusable dialog component implementation

## Testing
- `pnpm lint` (fails: 'error' is never reassigned. Use 'const' instead)
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae201530fc8324a326cce61190e760