### PR TITLE
Refactor AddNoteForm to use shared Form components

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export { Button } from "./button";
 export { Input } from "./input";
 export { Form, FormField } from "./form";
+export { Textarea } from "./textarea";


### PR DESCRIPTION
## Summary
- use shared `Form`, `FormField`, and `Textarea` components in AddNoteForm
- expose `Textarea` from UI index for consolidated imports

## Testing
- `pnpm lint src/components/AddNoteForm.tsx src/components/ui/index.ts`
- `pnpm test tests/addnoteform.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae216dc2848324bfa9c9aa00b4faa0