### PR TITLE
refactor: tweak photo gallery button variants

### DIFF
--- a/src/components/plant/PhotoGalleryClient.tsx
+++ b/src/components/plant/PhotoGalleryClient.tsx
@@ -65,9 +65,9 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
           <Button
             type="button"
             aria-label="Previous"
-            variant="ghost"
+            variant="outline"
             size="icon"
-            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 shadow"
+            className="absolute left-2 top-1/2 -translate-y-1/2"
             onClick={() => scrollByDir(-1)}
           >
             <ChevronLeft className="h-4 w-4" />
@@ -75,9 +75,9 @@ export default function PhotoGalleryClient({ events }: { events: CareEvent[] }) 
           <Button
             type="button"
             aria-label="Next"
-            variant="ghost"
+            variant="outline"
             size="icon"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-background/70 shadow"
+            className="absolute right-2 top-1/2 -translate-y-1/2"
             onClick={() => scrollByDir(1)}
           >
             <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- use shadcn dialog wrapper and button components in photo gallery
- style gallery navigation with outline button variant

## Testing
- `pnpm test` *(fails: ReferenceError: note is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae221108b88324993b8d93e1770c21