### PR TITLE
feat: add textarea component

### DIFF
--- a/src/components/AddNoteForm.tsx
+++ b/src/components/AddNoteForm.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { CareEvent } from '@/types';
-import { Form, FormField, Textarea } from '@/components/ui';
+import { Form, FormField } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { queueEvent } from '@/lib/offlineQueue';

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,8 +9,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background",
-          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm",
+          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}


### PR DESCRIPTION
## Summary
- add shadcn Textarea component
- use Textarea in AddNoteForm

## Testing
- `pnpm lint` (fails: 'error' is never reassigned. Use 'const' instead)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2946783883248bc8f7122aa4ca80