### PR TITLE
fix: handle missing Supabase envs without 500 errors

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,12 +1,5 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!
-  if (!url || !key) throw new Error("Missing SUPABASE env vars")
-  return createClient(url, key, { auth: { persistSession: false } })
-}
+import { supabaseServer } from "@/lib/supabase/server"
 
 export async function GET() {
   try {

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,14 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "@/lib/auth";
 import cloudinary from "@/lib/cloudinary";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) throw new Error("Missing SUPABASE env vars");
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET(req: Request) {
   try {

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,15 +1,6 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { toCsv } from "@/lib/csv";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) {
-    throw new Error("Missing SUPABASE env vars. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET(req: Request) {
   try {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,15 +1,6 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) {
-    throw new Error("Missing SUPABASE env vars. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 const plantSchema = z.object({
   id: z.string().uuid().optional(),

--- a/src/app/api/notifications/settings/route.ts
+++ b/src/app/api/notifications/settings/route.ts
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "@/lib/auth";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) throw new Error("Missing SUPABASE env vars");
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET() {
   try {

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { getCurrentUserId } from "@/lib/auth";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) throw new Error("Missing SUPABASE env vars");
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET(
   _req: Request,

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,14 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  if (!url || !key) {
-    throw new Error("Missing SUPABASE env vars. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET() {
   try {

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,19 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
-function supabaseServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  const missing: string[] = [];
-  if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL");
-  if (!key) missing.push("SUPABASE_SERVICE_ROLE_KEY");
-  if (missing.length) {
-    const message = `Missing env vars: ${missing.join(", ")}`;
-    console.error(message);
-    throw new Error(message);
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
-}
+import { supabaseServer } from "@/lib/supabase/server";
 
 export async function GET() {
   try {


### PR DESCRIPTION
## Summary
- use shared Supabase server helper in API routes
- avoid hard failures when Supabase env vars are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2bc1524c8324a1e361752c14ba96