### PR TITLE
Handle flexible species API results

### DIFF
--- a/__tests__/species-autosuggest.test.tsx
+++ b/__tests__/species-autosuggest.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import SpeciesAutosuggest from "@/components/plant/SpeciesAutosuggest";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
+
+vi.mock("@/lib/use-debounce", () => ({
+  useDebounce: (v: string) => v,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SpeciesAutosuggest", () => {
+  it("displays suggestions from array response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ scientific: "Ficus lyrata", common: "Fiddle" }],
+    } as any);
+
+    render(<SpeciesAutosuggest onSelect={() => {}} />);
+    const input = screen.getByPlaceholderText(/search species/i);
+    fireEvent.change(input, { target: { value: "fi" } });
+
+    expect(await screen.findByText("Fiddle")).toBeInTheDocument();
+  });
+
+  it("displays suggestions from results response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ scientific: "Monstera deliciosa" }] }),
+    } as any);
+
+    render(<SpeciesAutosuggest onSelect={() => {}} />);
+    const input = screen.getByPlaceholderText(/search species/i);
+    fireEvent.change(input, { target: { value: "mon" } });
+
+    expect(await screen.findByText("Monstera deliciosa")).toBeInTheDocument();
+  });
+});
+

--- a/src/components/plant/SpeciesAutosuggest.tsx
+++ b/src/components/plant/SpeciesAutosuggest.tsx
@@ -34,8 +34,13 @@ export default function SpeciesAutosuggest(props: {
         return;
       }
       const res = await fetch(`/api/species?q=${encodeURIComponent(debounced)}`);
-      const json = await res.json().catch(() => ({ results: [] }));
-      if (!cancelled) setItems(Array.isArray(json?.results) ? json.results : []);
+      const json = await res.json().catch(() => []);
+      const items = Array.isArray(json)
+        ? json
+        : Array.isArray((json as any)?.results)
+          ? (json as any).results
+          : [];
+      if (!cancelled) setItems(items);
     }
     go();
     return () => {


### PR DESCRIPTION
## Summary
- handle species search results when API returns array or `{results}` shape
- add tests covering both response formats

## Testing
- `pnpm lint` *(fails: 'error' is never reassigned in src/app/today/page.tsx)*
- `pnpm test __tests__/species-autosuggest.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f69838c8324bb54e172f4a4b390