### PR TITLE
Refactor tasks page and refresh shadcn UI primitives

### DIFF
--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,11 +1,55 @@
-// src/app/today/page.tsx
 import TaskList from "@/components/TaskList";
 import { generateTasks } from "@/lib/tasks";
 import type { Plant } from "@/lib/tasks";
 import type { Task } from "@/types/task";
-import { createClient } from "@supabase/supabase-js";
 
-// --- Fallback sample plants (your current mock) ---
+// NOTE: we lazy-import supabase in the loader so the page still
+// renders fine without the package in dev/canvas environments.
+async function getTasksFromSupabase(): Promise<Task[] | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anon) return null;
+
+  let createClient: any;
+  try {
+    const mod = await import("@supabase/supabase-js");
+    createClient = mod.createClient;
+  } catch {
+    return null; // package not present / edge preview → fallback
+  }
+  const supabase = createClient(url, anon);
+
+  // Prefer a view if present
+  const { data: initialData, error } = await supabase
+    .from("tasks_today_view")
+    .select("*");
+  let data = initialData;
+
+  if (error || !data) {
+    const res = await supabase
+      .from("tasks")
+      .select("id, plant_id, plant_name, type, due_at, status")
+      .gte("due_at", new Date(Date.now() - 14 * 86400000).toISOString());
+    if (res.error || !res.data) return null;
+    data = res.data as any[];
+  }
+
+  // Ensure we never pass Promises into JSX
+  return (data as any[]).map((row) => {
+    const dueISO =
+      row?.due_at ?? row?.dueAt ?? row?.due ?? new Date().toISOString();
+    return {
+      id: String(row.id ?? row.task_id ?? `${row.plant_id}-${row.type}`),
+      due: new Date(dueISO).toISOString(),
+      type: (row?.type ?? row?.task_type ?? "water") as Task["type"],
+      plantName: row?.plant_name ?? row?.nickname ?? "Plant",
+      plantId: row?.plant_id ?? undefined,
+      status: row?.status ?? undefined,
+    } satisfies Task;
+  });
+}
+
+// --- Fallback sample plants (kept for local/dev) ---
 const samplePlants: Plant[] = [
   {
     id: "1",
@@ -27,59 +71,16 @@ const samplePlants: Plant[] = [
   },
 ];
 
-// Normalize any DB row into your Task shape (at least id + due)
-function toTask(row: any): Task {
-  // Try a handful of likely column names, then fall back to "today"
-  const dueISO =
-    row?.due_at ??
-    row?.dueAt ??
-    row?.due ??
-    new Date().toISOString();
-
-  return {
-    id: String(row.id ?? row.task_id ?? crypto.randomUUID()),
-    // Your TaskList only requires .due; TaskCard can use extras if present:
-    due: new Date(dueISO).toISOString(),
-    // Optional nice-to-haves if your Task type includes them
-    type: row?.type ?? row?.task_type,                // 'water' | 'fertilize'
-    plantName: row?.plant_name ?? row?.nickname ?? "", // used by TaskCard if available
-    plantId: row?.plant_id ?? undefined,
-    status: row?.status ?? undefined,
-  } as Task;
-}
-
-async function getTasksFromSupabase(): Promise<Task[] | null> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anon) return null;
-
-  const supabase = createClient(url, anon);
-
-  // Prefer a view if you created one that already returns what's due/overdue/upcoming
-  const { data, error } = await supabase.from("tasks_today_view").select("*");
-
-  // If the view doesn't exist, fall back to a generic tasks query
-  if (error || !data) {
-    const res = await supabase
-      .from("tasks")
-      .select("id, plant_id, plant_name, type, due_at, status")
-      .gte("due_at", new Date(Date.now() - 14 * 86400000).toISOString());
-    if (res.error || !res.data) return null;
-    data = res.data as any[];
-  }
-
-  return (data as any[]).map(toTask);
-}
-
 export default async function TodayPage() {
   // Try DB first; otherwise compute from sample plants
   const dbTasks = await getTasksFromSupabase();
-  const tasks = dbTasks && dbTasks.length > 0 ? dbTasks : generateTasks(samplePlants);
+  const tasks = (dbTasks?.length ? dbTasks : generateTasks(samplePlants)) as Task[];
 
   return (
-    <section className="p-4 space-y-4">
+    <section className="space-y-6 px-4 py-6 md:px-6">
       <h1 className="text-2xl font-semibold">Today&apos;s Tasks</h1>
       <TaskList tasks={tasks} />
     </section>
   );
 }
+

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -29,16 +29,16 @@ export default function TaskCard({
 
   return (
     <Card>
-      <CardContent className="p-3 flex items-center gap-3">
-        <Avatar className="h-8 w-8">
+      <CardContent className="flex items-center gap-3 p-3">
+        <Avatar className="h-9 w-9">
           <AvatarFallback>{icon}</AvatarFallback>
         </Avatar>
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
-              <div className="font-medium truncate">{task.plantName ?? "Plant"}</div>
-              <div className="text-xs text-muted-foreground capitalize">
+              <div className="truncate font-medium">{task.plantName ?? "Plant"}</div>
+              <div className="text-xs capitalize text-muted-foreground">
                 {task.type ?? "water"} • {format(due, "MMM d")}
               </div>
             </div>
@@ -58,7 +58,11 @@ export default function TaskCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {[1, 3, 7].map((d) => (
-                <DropdownMenuItem key={d} onSelect={() => onSnooze(d)} className="text-xs">
+                <DropdownMenuItem
+                  key={d}
+                  onSelect={() => onSnooze(d)}
+                  className="text-xs"
+                >
                   Snooze {d}d
                 </DropdownMenuItem>
               ))}
@@ -76,3 +80,4 @@ export default function TaskCard({
     </Card>
   );
 }
+

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -17,7 +17,7 @@ import EmptyTasksState from "@/components/EmptyTasksState";
 import { apiFetch } from "@/lib/api";
 
 // shadcn/ui
-import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
@@ -36,7 +36,7 @@ export default function TaskList({ tasks: initialTasks }: { tasks: Task[] }) {
       });
       confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
     } catch {
-      setTasks(previous);
+      setTasks(previous); // toast handled in apiFetch
     }
   };
 
@@ -112,16 +112,16 @@ function TaskSection({
   onSnooze: (id: string, days?: number) => void | Promise<void>;
 }) {
   return (
-    <Card className="border-muted/40">
-      <CardHeader className="flex-row items-center justify-between">
-        <h2 className="text-lg font-semibold">{label}</h2>
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-lg">{label}</CardTitle>
         <Badge variant="secondary">{items.length}</Badge>
       </CardHeader>
-      <CardContent>
+      <CardContent className="pt-4">
         {items.length === 0 ? (
           <p className="text-sm text-muted-foreground">Nothing here 🎉</p>
         ) : (
-          <motion.ul layout className="space-y-4 list-none pl-0">
+          <motion.ul layout className="list-none space-y-4 pl-0">
             <AnimatePresence>
               {items.map((task) => (
                 <TaskItem
@@ -148,9 +148,9 @@ function TaskItem({
   onComplete: (id: string) => void | Promise<void>;
   onSnooze: (id: string, days?: number) => void | Promise<void>;
 }) {
-  const [startX, setStartX] = React.useState<number | null>(null);
-  const [offsetX, setOffsetX] = React.useState(0);
-  const [pending, setPending] = React.useState(false);
+  const [startX, setStartX] = useState<number | null>(null);
+  const [offsetX, setOffsetX] = useState(0);
+  const [pending, setPending] = useState(false);
 
   const complete = () => {
     if (pending) return;
@@ -179,11 +179,15 @@ function TaskItem({
         else setOffsetX(0);
         setStartX(null);
       }}
-      onPointerLeave={startX !== null ? () => {
-        if (offsetX > 100 && !pending) complete();
-        else setOffsetX(0);
-        setStartX(null);
-      } : undefined}
+      onPointerLeave={
+        startX !== null
+          ? () => {
+              if (offsetX > 100 && !pending) complete();
+              else setOffsetX(0);
+              setStartX(null);
+            }
+          : undefined
+      }
       onPointerCancel={() => {
         setOffsetX(0);
         setStartX(null);
@@ -206,3 +210,4 @@ function TaskItem({
     </motion.li>
   );
 }
+

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
 import { cn } from "@/lib/utils";
 
 const Avatar = React.forwardRef<
@@ -10,7 +11,10 @@ const Avatar = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Root
     ref={ref}
-    className={cn("relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full", className)}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
     {...props}
   />
 ));
@@ -20,7 +24,11 @@ const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
@@ -30,10 +38,14 @@ const AvatarFallback = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Fallback
     ref={ref}
-    className={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
     {...props}
   />
 ));
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
 export { Avatar, AvatarImage, AvatarFallback };
+

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,19 +1,23 @@
 import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps, cva } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground border-transparent",
-        secondary:
-          "bg-secondary text-secondary-foreground border-transparent",
-        outline: "text-foreground",
-      },
+      default:
+        "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+      secondary:
+        "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      destructive:
+        "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+      outline: "text-foreground",
     },
-    defaultVariants: { variant: "default" },
+    defaultVariants: {
+      variant: "default",
+    },
   }
 );
 
@@ -28,3 +32,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
 }
 
 export { Badge, badgeVariants };
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,17 +1,21 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps, cva } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:opacity-90",
-        secondary: "bg-secondary text-secondary-foreground hover:opacity-90",
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
@@ -22,7 +26,10 @@ const buttonVariants = cva(
         icon: "h-9 w-9",
       },
     },
-    defaultVariants: { variant: "default", size: "default" },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
   }
 );
 
@@ -37,7 +44,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size }), className)}
+        className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
@@ -47,3 +54,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = "Button";
 
 export { Button, buttonVariants };
+

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,40 +1,66 @@
 import * as React from "react";
+
 import { cn } from "@/lib/utils";
 
-function Card({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm",
-        className
-      )}
-      {...props}
-    />
-  );
-}
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+    {...props}
+  />
+));
+Card.displayName = "Card";
 
-function CardHeader({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />;
-}
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
 
-function CardTitle({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLHeadingElement>) {
-  return <h3 className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />;
-}
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
 
-function CardContent({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-6 pt-0", className)} {...props} />;
-}
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
 
-export { Card, CardHeader, CardTitle, CardContent };
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,36 +2,87 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
+
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Content
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
     ref={ref}
-    sideOffset={sideOffset}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+      "flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 data-[side=right]:slide-in-from-left-2 data-[side=left]:slide-in-from-right-2",
       className
     )}
     {...props}
   />
 ));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 data-[side=right]:slide-in-from-left-2 data-[side=left]:slide-in-from-right-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none " +
-        "focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground",
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
       className
     )}
     {...props}
@@ -39,9 +90,103 @@ const DropdownMenuItem = React.forwardRef<
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
 };
+


### PR DESCRIPTION
## Summary
- Lazy-load Supabase and normalize task data in today page
- Rebuild TaskList and TaskCard with shadcn-compliant UI
- Update card, button, badge, avatar, and dropdown primitives to latest shadcn recipes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: GET /api/rooms returns fetch failed instead of env var error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a1ad2dc83248bf17a7102f7495d