### PR TITLE
fix: await params in PlantDetail page

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -35,9 +35,10 @@ async function getPlant(id: string): Promise<PlantRow | null> {
 export default async function PlantDetail({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
-  const plant = await getPlant(params.id);
+  const { id } = await params;
+  const plant = await getPlant(id);
   if (!plant) notFound();
 
   return (


### PR DESCRIPTION
## Summary
- await route params in PlantDetail before fetching plant

## Testing
- `pnpm lint`
- `pnpm test` (fails: 3 failed | 45 passed)
- `pnpm dev` + `curl -I http://localhost:3000/plants/1`


------
https://chatgpt.com/codex/tasks/task_e_68ae3ce5e55c8324a8e7a98daa1526f1