### PR TITLE
Use shared fallback plant data when Supabase missing

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -2,21 +2,15 @@ import { notFound } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-
-type PlantRow = {
-  id: string;
-  nickname: string;
-  species?: string | null;
-  water_every?: string | null;
-  fert_every?: string | null;
-  last_watered_at?: string | null;
-  last_fertilized_at?: string | null;
-};
+import {
+  type PlantRow,
+  getFallbackPlant,
+} from "@/lib/fallbackPlants";
 
 async function getPlant(id: string): Promise<PlantRow | null> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anon) return null;
+  if (!url || !anon) return getFallbackPlant(id);
   try {
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(url, anon);
@@ -25,10 +19,10 @@ async function getPlant(id: string): Promise<PlantRow | null> {
       .select("*")
       .eq("id", id)
       .maybeSingle();
-    if (error) return null;
+    if (error || !data) return getFallbackPlant(id);
     return data as PlantRow;
   } catch {
-    return null;
+    return getFallbackPlant(id);
   }
 }
 

--- a/src/app/plants/page.tsx
+++ b/src/app/plants/page.tsx
@@ -1,70 +1,36 @@
 import PlantCard, { type PlantCardProps } from "@/components/PlantCard";
+import {
+  type PlantRow,
+  fallbackPlants,
+} from "@/lib/fallbackPlants";
 
-type Row = {
-  id: string;
-  nickname: string;
-  species?: string | null;
-  lastWateredAt?: string | null;
-  lastFertilizedAt?: string | null;
-  waterEvery?: string | null;
-  fertEvery?: string | null;
-};
+function rowToProps(row: PlantRow): PlantCardProps {
+  return {
+    id: String(row.id),
+    nickname: row.nickname,
+    species: row.species ?? null,
+    lastWateredAt: row.last_watered_at ?? null,
+    lastFertilizedAt: row.last_fertilized_at ?? null,
+    waterEvery: row.water_every ?? null,
+    fertEvery: row.fert_every ?? null,
+  };
+}
 
 async function getPlants(): Promise<PlantCardProps[]> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anon) return fallbackPlants;
+  if (!url || !anon) return fallbackPlants.map(rowToProps);
 
   try {
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(url, anon);
-    const { data, error } = await supabase
-      .from("plants")
-      .select(
-        "id, nickname, species, lastWateredAt:last_watered_at, lastFertilizedAt:last_fertilized_at, waterEvery:water_every, fertEvery:fert_every"
-      );
-    if (error || !data) return fallbackPlants;
-    return (data as Row[]).map((r) => ({
-      id: String(r.id),
-      nickname: r.nickname,
-      species: r.species ?? null,
-      lastWateredAt: r.lastWateredAt ?? null,
-      lastFertilizedAt: r.lastFertilizedAt ?? null,
-      waterEvery: r.waterEvery ?? null,
-      fertEvery: r.fertEvery ?? null,
-    }));
+    const { data, error } = await supabase.from("plants").select("*");
+    if (error || !data) return fallbackPlants.map(rowToProps);
+    return (data as PlantRow[]).map(rowToProps);
   } catch {
-    return fallbackPlants;
+    return fallbackPlants.map(rowToProps);
   }
 }
-
-const fallbackPlants: PlantCardProps[] = [
-  {
-    id: "1",
-    nickname: "Monstera",
-    species: "Deliciosa",
-    waterEvery: "7 days",
-    lastWateredAt: new Date(Date.now() - 8 * 86_400_000).toISOString(),
-  },
-  {
-    id: "2",
-    nickname: "Fiddle Leaf Fig",
-    species: "Ficus lyrata",
-    fertEvery: "30 days",
-    lastFertilizedAt: new Date(
-      Date.now() - 30 * 86_400_000
-    ).toISOString(),
-  },
-  {
-    id: "3",
-    nickname: "Snake Plant",
-    species: "Dracaena trifasciata",
-    waterEvery: "14 days",
-    lastWateredAt: new Date(
-      Date.now() - 10 * 86_400_000
-    ).toISOString(),
-  },
-];
 
 export default async function PlantsPage() {
   const plants = await getPlants();

--- a/src/lib/fallbackPlants.ts
+++ b/src/lib/fallbackPlants.ts
@@ -1,0 +1,41 @@
+export type PlantRow = {
+  id: string;
+  nickname: string;
+  species?: string | null;
+  water_every?: string | null;
+  fert_every?: string | null;
+  last_watered_at?: string | null;
+  last_fertilized_at?: string | null;
+};
+
+export const fallbackPlants: PlantRow[] = [
+  {
+    id: "1",
+    nickname: "Monstera",
+    species: "Deliciosa",
+    water_every: "7 days",
+    last_watered_at: new Date(Date.now() - 8 * 86_400_000).toISOString(),
+  },
+  {
+    id: "2",
+    nickname: "Fiddle Leaf Fig",
+    species: "Ficus lyrata",
+    fert_every: "30 days",
+    last_fertilized_at: new Date(
+      Date.now() - 30 * 86_400_000
+    ).toISOString(),
+  },
+  {
+    id: "3",
+    nickname: "Snake Plant",
+    species: "Dracaena trifasciata",
+    water_every: "14 days",
+    last_watered_at: new Date(
+      Date.now() - 10 * 86_400_000
+    ).toISOString(),
+  },
+];
+
+export function getFallbackPlant(id: string): PlantRow | null {
+  return fallbackPlants.find((p) => p.id === id) ?? null;
+}


### PR DESCRIPTION
## Summary
- add shared fallback plant dataset and accessor
- use fallback when Supabase creds missing on plant list and detail pages

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No "notFound" export is defined on the "next/navigation" mock ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f837ec483249d959a07da52104c