### PR TITLE
chore: set local base URL

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- add `.env.local` with `NEXT_PUBLIC_BASE_URL=http://localhost:3000`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: [vitest] No "notFound" export is defined on the "next/navigation" mock, 6 failing tests)*
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68ae554274708324b3083b8b16b5ae19