### PR TITLE
Handle custom species input

### DIFF
--- a/__tests__/add-plant-form.test.tsx
+++ b/__tests__/add-plant-form.test.tsx
@@ -71,7 +71,7 @@ describe("AddPlantForm validation", () => {
 });
 
 describe("AddPlantForm submission", () => {
-  it("posts data and redirects to detail page", async () => {
+  it("posts typed species to both fields and redirects to detail page", async () => {
     global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       if (typeof input === "string" && input.startsWith("/api/ai-care/preview")) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ preview: "test" }) });
@@ -94,6 +94,13 @@ describe("AddPlantForm submission", () => {
     fireEvent.click(screen.getByRole("button", { name: /create plant/i }));
 
     await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/plants",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"speciesScientific":"Pothos"'),
+        })
+      );
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/plants",
         expect.objectContaining({

--- a/src/components/plant/AddPlantForm.tsx
+++ b/src/components/plant/AddPlantForm.tsx
@@ -79,7 +79,7 @@ export default function AddPlantForm(): JSX.Element {
     try {
       const payload: CreatePayload = {
         nickname: values.nickname.trim(),
-        speciesScientific: speciesScientific || null,
+        speciesScientific: (speciesScientific || values.species).trim(),
         speciesCommon: speciesCommon || values.species || null,
         room_id: values.room_id ?? null,
         pot: values.pot?.trim() || null,


### PR DESCRIPTION
## Summary
- ensure AddPlantForm falls back to user-typed species for `speciesScientific`
- extend AddPlantForm test to verify both `speciesScientific` and `speciesCommon` are sent

## Testing
- `pnpm lint src/components/plant/AddPlantForm.tsx __tests__/add-plant-form.test.tsx`
- `pnpm test __tests__/add-plant-form.test.tsx`
- `pnpm test` *(fails: [vitest] No `notFound` export is defined on the `next/navigation` mock; rooms.api.test requires env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68ae557a3a508324a0344349baf49885