### PR TITLE
Handle missing Supabase configuration

### DIFF
--- a/src/app/api/ai-care/route.ts
+++ b/src/app/api/ai-care/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getAiCareSuggestions, getAiCareAnswer } from "@/lib/aiCare";
+import { SupabaseEnvError } from "@/lib/supabaseAdmin";
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -15,7 +16,10 @@ export async function GET(req: Request) {
     }
     const suggestions = await getAiCareSuggestions(plantId);
     return NextResponse.json({ suggestions });
-  } catch {
+  } catch (e) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
 }

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { supabaseServer } from "@/lib/supabase/server"
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server"
 
 export async function GET() {
   try {
@@ -177,6 +177,9 @@ export async function GET() {
       { status: 200 }
     )
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 })
+    }
     const msg = e instanceof Error ? e.message : "Server error"
     return NextResponse.json({ error: msg }, { status: 500 })
   }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentUserId } from "@/lib/auth";
 import cloudinary from "@/lib/cloudinary";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET(req: Request) {
   try {
@@ -24,6 +24,9 @@ export async function GET(req: Request) {
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json(data ?? [], { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -121,6 +124,9 @@ export async function POST(req: Request) {
     const event = data?.[0] ?? null;
     return NextResponse.json({ event }, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { toCsv } from "@/lib/csv";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET(req: Request) {
   try {
@@ -32,6 +32,9 @@ export async function GET(req: Request) {
       { status: 200 },
     );
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 const plantSchema = z.object({
   id: z.string().uuid().optional(),
@@ -66,6 +66,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     if (e instanceof z.ZodError) {
       return NextResponse.json({ error: e.message }, { status: 400 });
     }

--- a/src/app/api/notifications/digest/route.ts
+++ b/src/app/api/notifications/digest/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
-import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { supabaseAdmin, SupabaseEnvError } from "@/lib/supabaseAdmin";
 import { getCurrentUserId } from "@/lib/auth";
 
 export async function GET(req: Request) {
   try {
     const userId = await getCurrentUserId();
     const today = new Date().toISOString().slice(0, 10);
-    const { data: tasks, error } = await supabaseAdmin
+    const supabase = supabaseAdmin();
+    const { data: tasks, error } = await supabase
       .from("tasks")
       .select("id, plant_id, type, due_date")
       .eq("user_id", userId)
@@ -23,6 +24,9 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ ok: true, summary, tasks: list });
   } catch (err) {
+    if (err instanceof SupabaseEnvError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: 503 });
+    }
     const message = err instanceof Error ? err.message : "Server error";
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }

--- a/src/app/api/notifications/settings/route.ts
+++ b/src/app/api/notifications/settings/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCurrentUserId } from "@/lib/auth";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET() {
   try {
@@ -14,6 +14,9 @@ export async function GET() {
     if (error) throw error;
     return NextResponse.json({ settings: data }, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -37,6 +40,9 @@ export async function PATCH(req: Request) {
     if (error) throw error;
     return NextResponse.json({ settings: data }, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/app/api/plants/[id]/route.ts
+++ b/src/app/api/plants/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCurrentUserId } from "@/lib/auth";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET(
   _req: Request,
@@ -24,6 +24,9 @@ export async function GET(
     }
     return NextResponse.json(Array.isArray(data) ? data[0] : data, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -65,6 +68,9 @@ export async function PATCH(
     const updated = Array.isArray(data) ? data[0] : data;
     return NextResponse.json({ plant: updated }, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -86,6 +92,9 @@ export async function DELETE(
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({}, { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/app/api/plants/route.ts
+++ b/src/app/api/plants/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET() {
   try {
@@ -19,6 +19,9 @@ export async function GET() {
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json(data ?? [], { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -49,6 +52,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ plant }, { status: 201 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCurrentUserId } from "@/lib/auth";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET() {
   try {
@@ -19,6 +19,9 @@ export async function GET() {
       { status: 200 },
     );
   } catch (err) {
+    if (err instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: err.message }, { status: 503 });
+    }
     if (err instanceof Error && err.message === "Unauthorized") {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { supabaseServer } from "@/lib/supabase/server";
+import { supabaseServer, SupabaseEnvError } from "@/lib/supabase/server";
 
 export async function GET() {
   try {
@@ -11,6 +11,9 @@ export async function GET() {
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json(data ?? [], { status: 200 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
@@ -27,6 +30,9 @@ export async function POST(req: Request) {
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({ room: data }, { status: 201 });
   } catch (e: unknown) {
+    if (e instanceof SupabaseEnvError) {
+      return NextResponse.json({ error: e.message }, { status: 503 });
+    }
     const msg = e instanceof Error ? e.message : "Server error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }

--- a/src/components/plant/QuickStats.tsx
+++ b/src/components/plant/QuickStats.tsx
@@ -20,7 +20,8 @@ function parseInterval(value?: string | null) {
 
 export default async function QuickStats({ plant }: QuickStatsProps) {
   const userId = await getCurrentUserId();
-  const { data: waterEvents } = await supabaseAdmin
+  const supabase = supabaseAdmin();
+  const { data: waterEvents } = await supabase
     .from("events")
     .select("created_at")
     .eq("plant_id", plant.id)

--- a/src/lib/aiCare.ts
+++ b/src/lib/aiCare.ts
@@ -21,7 +21,8 @@ function getSeason(date: Date): "winter" | "spring" | "summer" | "fall" {
 
 export async function getAiCareContext(plantId: string): Promise<CareContext> {
   const userId = await getCurrentUserId();
-  const { data: events } = await supabaseAdmin
+  const supabase = supabaseAdmin();
+  const { data: events } = await supabase
     .from("events")
     .select("type, note, created_at")
     .eq("user_id", userId)
@@ -54,8 +55,9 @@ export async function getAiCareContext(plantId: string): Promise<CareContext> {
 export async function getAiCareSuggestions(plantId: string) {
   const userId = await getCurrentUserId();
   const today = new Date().toISOString().slice(0, 10);
+  const supabase = supabaseAdmin();
 
-  const { data: tasks, error } = await supabaseAdmin
+  const { data: tasks, error } = await supabase
     .from("tasks")
     .select("type, due_date")
     .eq("user_id", userId)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,7 +21,9 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
     } catch {
       // ignore JSON parse errors
     }
-    if (res.status === 401 || res.status === 403) {
+    if (res.status === 503 && message.toLowerCase().includes('supabase')) {
+      message = 'Supabase credentials missing or server not running';
+    } else if (res.status === 401 || res.status === 403) {
       message = 'You do not have permission to perform this action';
     }
     if (typeof window !== 'undefined') {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,16 +1,31 @@
 import { createClient } from "@supabase/supabase-js";
 
+export class SupabaseEnvError extends Error {
+  constructor(missing: string[]) {
+    super(`Supabase environment variables missing: ${missing.join(", ")}`);
+    this.name = "SupabaseEnvError";
+  }
+}
+
+function getConfig() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const missing: string[] = [];
+  if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL");
+  if (!key) missing.push("SUPABASE_SERVICE_ROLE_KEY");
+  if (missing.length) {
+    throw new SupabaseEnvError(missing);
+  }
+  return { url, key };
+}
+
 /**
  * Server-side Supabase client using the service role key.
- *
- * Defaults to localhost values when environment variables are missing so that
- * tests can run without real credentials.
  */
 export function supabaseServer() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost",
-    process.env.SUPABASE_SERVICE_ROLE_KEY || "service-role-key",
-    { auth: { persistSession: false } },
-  );
+  const { url, key } = getConfig();
+  return createClient(url, key, { auth: { persistSession: false } });
 }
+
+export { getConfig as getSupabaseConfig };
 

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,14 +1,12 @@
 import { createClient } from "@supabase/supabase-js";
+import { getSupabaseConfig, SupabaseEnvError } from "@/lib/supabase/server";
 
 /**
  * Server-side Supabase client authenticated with the service role key.
- *
- * This client has elevated privileges and should only be used in secure
- * server-side environments such as API routes. If environment variables are
- * missing, a dummy client is created for tests.
  */
-export const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "http://localhost",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "service-role-key",
-);
+export function supabaseAdmin() {
+  const { url, key } = getSupabaseConfig();
+  return createClient(url, key);
+}
 
+export { SupabaseEnvError } from "@/lib/supabase/server";

--- a/tests/plant.page.test.tsx
+++ b/tests/plant.page.test.tsx
@@ -72,7 +72,7 @@ vi.mock("@/lib/db", () => ({
     plant: {
       findFirst: () =>
         Promise.resolve({
-          id: "plant-1",
+          id: "1",
           nickname: "My Plant",
           speciesScientific: "Pothos",
           imageUrl: null,
@@ -90,7 +90,7 @@ vi.mock("@/lib/db", () => ({
 
 const mockOrder = vi.fn();
 vi.mock("@/lib/supabaseAdmin", () => ({
-  supabaseAdmin: {
+  supabaseAdmin: () => ({
     from: () => ({
       select: () => ({
         eq: () => ({
@@ -100,7 +100,7 @@ vi.mock("@/lib/supabaseAdmin", () => ({
         }),
       }),
     }),
-  },
+  }),
 }));
 
 beforeEach(() => {
@@ -111,14 +111,14 @@ beforeEach(() => {
 describe("PlantDetailPage", () => {
   it("falls back to latest photo when plant has no main image", async () => {
     const PlantDetailPage = (await import("../src/app/plants/[id]/page")).default;
-    const element = await PlantDetailPage({ params: Promise.resolve({ id: "plant-1" }) });
+    const element = await PlantDetailPage({ params: Promise.resolve({ id: "1" }) });
     const html = renderToString(element);
     expect(html).toContain("https://example.com/latest.jpg");
   });
 
   it("shows plant name, species, and room", async () => {
     const PlantDetailPage = (await import("../src/app/plants/[id]/page")).default;
-    const element = await PlantDetailPage({ params: Promise.resolve({ id: "plant-1" }) });
+    const element = await PlantDetailPage({ params: Promise.resolve({ id: "1" }) });
     const html = renderToString(element);
     expect(html).toContain("My Plant");
     expect(html).toContain("Pothos");
@@ -127,7 +127,7 @@ describe("PlantDetailPage", () => {
 
   it("renders mark as watered button", async () => {
     const PlantDetailPage = (await import("../src/app/plants/[id]/page")).default;
-    const element = await PlantDetailPage({ params: Promise.resolve({ id: "plant-1" }) });
+    const element = await PlantDetailPage({ params: Promise.resolve({ id: "1" }) });
     const html = renderToString(element);
     expect(html).toContain("Mark as watered");
   });
@@ -135,7 +135,7 @@ describe("PlantDetailPage", () => {
   it("sets timelineError when events fetch fails", async () => {
     mockOrder.mockResolvedValueOnce({ data: null, error: { message: "fail" } });
     const PlantDetailPage = (await import("../src/app/plants/[id]/page")).default;
-    const element = await PlantDetailPage({ params: Promise.resolve({ id: "plant-1" }) });
+    const element = await PlantDetailPage({ params: Promise.resolve({ id: "1" }) });
     renderToString(element);
     expect(plantTabsMock).toHaveBeenCalled();
     expect(plantTabsMock.mock.calls[0][0].timelineError).toBe(true);

--- a/tests/plants.page.test.tsx
+++ b/tests/plants.page.test.tsx
@@ -6,6 +6,7 @@ import { renderToString } from 'react-dom/server';
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
 
 vi.mock('@/lib/auth', () => ({
   getCurrentUserId: () => Promise.resolve('user-123'),

--- a/tests/quickstats.test.tsx
+++ b/tests/quickstats.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/lib/auth", () => ({
 const lastDate = new Date("2025-01-01T00:00:00Z");
 
 vi.mock("@/lib/supabaseAdmin", () => ({
-  supabaseAdmin: {
+  supabaseAdmin: () => ({
     from: () => ({
       select: () => ({
         eq: () => ({
@@ -28,7 +28,7 @@ vi.mock("@/lib/supabaseAdmin", () => ({
         }),
       }),
     }),
-  },
+  }),
 }));
 
 describe("QuickStats", () => {

--- a/tests/rooms.api.test.ts
+++ b/tests/rooms.api.test.ts
@@ -18,7 +18,7 @@ describe("GET /api/rooms", () => {
     const res = await GET();
     const body = await res.json();
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(503);
     expect(body.error).toContain("NEXT_PUBLIC_SUPABASE_URL");
     expect(body.error).toContain("SUPABASE_SERVICE_ROLE_KEY");
 


### PR DESCRIPTION
## Summary
- Throw explicit error when Supabase env vars are absent and use across admin/server clients
- Return 503 from API routes when Supabase is not configured
- Surface friendly toast in client for missing Supabase credentials

## Testing
- `pnpm test` *(fails: tests/plant.page.test.tsx, tests/plants.page.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57ae91ac832491b97425a415b3c4