### PR TITLE
feat: improve form a11y

### DIFF
--- a/src/components/plant/AddPlantForm.tsx
+++ b/src/components/plant/AddPlantForm.tsx
@@ -42,6 +42,7 @@ export default function AddPlantForm(): JSX.Element {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    mode: "onChange",
     defaultValues: {
       nickname: "",
       species: "",
@@ -141,6 +142,7 @@ export default function AddPlantForm(): JSX.Element {
 
   const submitting = form.formState.isSubmitting;
   const totalSteps = 3;
+  const errorFields = Object.keys(form.formState.errors);
 
   async function handleNext() {
     if (step === 1) {
@@ -168,6 +170,11 @@ export default function AddPlantForm(): JSX.Element {
   return (
     <Form {...form}>
       <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+        <div aria-live="polite" className="sr-only">
+          {errorFields.length > 0
+            ? `Please fix the following fields: ${errorFields.join(", ")}.`
+            : ""}
+        </div>
         <div className="space-y-2">
           <div className="w-full bg-secondary rounded-full h-2">
             <div
@@ -186,9 +193,18 @@ export default function AddPlantForm(): JSX.Element {
               render={({ field }) => (
                 <div className="space-y-2">
                   <Label htmlFor="nickname">Nickname</Label>
-                  <Input id="nickname" placeholder="e.g. Kay" className="h-10" {...field} />
+                  <Input
+                    id="nickname"
+                    placeholder="e.g. Kay"
+                    className="h-10"
+                    aria-invalid={!!form.formState.errors.nickname}
+                    aria-describedby={
+                      form.formState.errors.nickname ? "nickname-error" : undefined
+                    }
+                    {...field}
+                  />
                   {form.formState.errors.nickname && (
-                    <p className="text-sm text-destructive">
+                    <p id="nickname-error" className="text-sm text-destructive">
                       {form.formState.errors.nickname.message}
                     </p>
                   )}
@@ -217,9 +233,16 @@ export default function AddPlantForm(): JSX.Element {
                       setPreviewError(null);
                       field.onChange(val);
                     }}
+                    inputProps={{
+                      id: "species",
+                      "aria-invalid": !!form.formState.errors.species,
+                      "aria-describedby": form.formState.errors.species
+                        ? "species-error"
+                        : undefined,
+                    }}
                   />
                   {form.formState.errors.species && (
-                    <p className="text-sm text-destructive">
+                    <p id="species-error" className="text-sm text-destructive">
                       {form.formState.errors.species.message}
                     </p>
                   )}
@@ -372,7 +395,11 @@ export default function AddPlantForm(): JSX.Element {
               Next
             </Button>
           ) : (
-            <Button type="submit" className="ml-auto" disabled={submitting}>
+            <Button
+              type="submit"
+              className="ml-auto"
+              disabled={submitting || !form.formState.isValid}
+            >
               {submitting ? "Creating…" : "Create Plant"}
             </Button>
           )}

--- a/src/components/plant/SpeciesAutosuggest.tsx
+++ b/src/components/plant/SpeciesAutosuggest.tsx
@@ -20,8 +20,16 @@ export default function SpeciesAutosuggest(props: {
   onInputChange?: (val: string) => void;
   placeholder?: string;
   className?: string;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }) {
-  const { value = "", onSelect, onInputChange, placeholder = "Search species…", className } = props;
+  const {
+    value = "",
+    onSelect,
+    onInputChange,
+    placeholder = "Search species…",
+    className,
+    inputProps,
+  } = props;
   const [query, setQuery] = React.useState(value);
   const debounced = useDebounce(query, 350);
   const [items, setItems] = React.useState<Item[]>([]);
@@ -101,6 +109,7 @@ export default function SpeciesAutosuggest(props: {
         }}
         onFocus={() => setOpen(true)}
         onBlur={() => setOpen(false)}
+        {...inputProps}
       />
       {open && (
         <CommandList className="absolute z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md">


### PR DESCRIPTION
## Summary
- add ARIA attributes and live error summary to AddPlantForm
- disable create button until form is valid
- allow SpeciesAutosuggest to pass input props for accessibility

## Testing
- `pnpm test` *(fails: Found multiple elements; other unrelated test failures)*
- `pnpm test __tests__/add-plant-form.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af08c80ea083248ba987f28034c0da