### PR TITLE
Cancel stale preview fetches with AbortController

### DIFF
--- a/src/components/plant/SpeciesAutosuggest.tsx
+++ b/src/components/plant/SpeciesAutosuggest.tsx
@@ -122,7 +122,7 @@ export default function SpeciesAutosuggest(props: {
               <CommandEmpty>{error}</CommandEmpty>
               {query && (
                 <CommandItem value={query} onSelect={() => choose({ scientific: query })}>
-                  Use "{query}" anyway
+                  Use &quot;{query}&quot; anyway
                 </CommandItem>
               )}
             </>


### PR DESCRIPTION
## Summary
- abort in-flight care preview requests when a new search begins
- ignore aborted responses and cleanup state
- escape quotes in SpeciesAutosuggest to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test Files 3 failed | 45 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b54025883248527412457907127